### PR TITLE
feat(yoga): add desktop specialisations

### DIFF
--- a/nixos/amd/configuration.nix
+++ b/nixos/amd/configuration.nix
@@ -2,6 +2,54 @@
   lib,
   ...
 }:
+let
+  desktopSessions = [
+    "niri"
+    "plasma"
+  ];
+
+  mobilityProfiles = [
+    {
+      suffix = "docked";
+      onTheGo = false;
+    }
+    {
+      suffix = "on-the-go";
+      onTheGo = true;
+    }
+  ];
+
+  mkDesktopProfile =
+    {
+      desktopTag,
+      onTheGo ? false,
+    }:
+    {
+      system.nixos.tags = [
+        desktopTag
+      ]
+      ++ lib.optional onTheGo "on-the-go"
+      ++ lib.optional (!onTheGo) "docked";
+    };
+
+  mkDesktopSpecialisations =
+    profileConfig:
+    builtins.listToAttrs (
+      lib.concatMap (
+        session:
+        map (profile: {
+          name = "${session}-${profile.suffix}";
+          value.configuration = {
+            services.displayManager.defaultSession = lib.mkForce session;
+          }
+          // profileConfig {
+            desktopTag = session;
+            inherit (profile) onTheGo;
+          };
+        }) mobilityProfiles
+      ) desktopSessions
+    );
+in
 {
   imports = [
     ./hardware-configuration.nix
@@ -37,6 +85,8 @@
   # amd graphics
   boot.initrd.kernelModules = lib.mkAfter [ "amdgpu" ];
   services.xserver.videoDrivers = lib.mkAfter [ "amdgpu" ];
+
+  specialisation = mkDesktopSpecialisations mkDesktopProfile;
 
   # fingerprint
   services.fprintd.enable = true;

--- a/nixos/yoga/configuration.nix
+++ b/nixos/yoga/configuration.nix
@@ -4,6 +4,44 @@
   lib,
   ...
 }:
+let
+  mkGraphicsProfile =
+    {
+      desktopTag,
+      onTheGo ? false,
+    }:
+    {
+      system.nixos.tags = [
+        desktopTag
+      ]
+      ++ lib.optional onTheGo "on-the-go"
+      ++ lib.optional (!onTheGo) "docked";
+      hardware.nvidia.prime = {
+        offload = {
+          enable = lib.mkForce onTheGo;
+          enableOffloadCmd = lib.mkForce onTheGo;
+        };
+        sync.enable = lib.mkForce (!onTheGo);
+      };
+    };
+
+  mkDesktopSpecialisation =
+    {
+      name,
+      session,
+      onTheGo ? false,
+    }:
+    {
+      inherit name;
+      value.configuration = {
+        services.displayManager.defaultSession = lib.mkForce session;
+      }
+      // mkGraphicsProfile {
+        desktopTag = session;
+        inherit onTheGo;
+      };
+    };
+in
 {
   imports = [
     ./hardware-configuration.nix
@@ -33,6 +71,27 @@
   };
 
   hardware.nvidia-container-toolkit.enable = true;
+
+  specialisation = builtins.listToAttrs [
+    (mkDesktopSpecialisation {
+      name = "niri-docked";
+      session = "niri";
+    })
+    (mkDesktopSpecialisation {
+      name = "niri-on-the-go";
+      session = "niri";
+      onTheGo = true;
+    })
+    (mkDesktopSpecialisation {
+      name = "plasma-docked";
+      session = "plasma";
+    })
+    (mkDesktopSpecialisation {
+      name = "plasma-on-the-go";
+      session = "plasma";
+      onTheGo = true;
+    })
+  ];
 
   services.xserver.videoDrivers = lib.mkAfter [ "nvidia" ];
   boot.kernelModules = [ "kvm-intel" ];

--- a/nixos/yoga/configuration.nix
+++ b/nixos/yoga/configuration.nix
@@ -5,6 +5,22 @@
   ...
 }:
 let
+  desktopSessions = [
+    "niri"
+    "plasma"
+  ];
+
+  mobilityProfiles = [
+    {
+      suffix = "docked";
+      onTheGo = false;
+    }
+    {
+      suffix = "on-the-go";
+      onTheGo = true;
+    }
+  ];
+
   mkGraphicsProfile =
     {
       desktopTag,
@@ -25,22 +41,23 @@ let
       };
     };
 
-  mkDesktopSpecialisation =
-    {
-      name,
-      session,
-      onTheGo ? false,
-    }:
-    {
-      inherit name;
-      value.configuration = {
-        services.displayManager.defaultSession = lib.mkForce session;
-      }
-      // mkGraphicsProfile {
-        desktopTag = session;
-        inherit onTheGo;
-      };
-    };
+  mkDesktopSpecialisations =
+    profileConfig:
+    builtins.listToAttrs (
+      lib.concatMap (
+        session:
+        map (profile: {
+          name = "${session}-${profile.suffix}";
+          value.configuration = {
+            services.displayManager.defaultSession = lib.mkForce session;
+          }
+          // profileConfig {
+            desktopTag = session;
+            inherit (profile) onTheGo;
+          };
+        }) mobilityProfiles
+      ) desktopSessions
+    );
 in
 {
   imports = [
@@ -72,26 +89,7 @@ in
 
   hardware.nvidia-container-toolkit.enable = true;
 
-  specialisation = builtins.listToAttrs [
-    (mkDesktopSpecialisation {
-      name = "niri-docked";
-      session = "niri";
-    })
-    (mkDesktopSpecialisation {
-      name = "niri-on-the-go";
-      session = "niri";
-      onTheGo = true;
-    })
-    (mkDesktopSpecialisation {
-      name = "plasma-docked";
-      session = "plasma";
-    })
-    (mkDesktopSpecialisation {
-      name = "plasma-on-the-go";
-      session = "plasma";
-      onTheGo = true;
-    })
-  ];
+  specialisation = mkDesktopSpecialisations mkGraphicsProfile;
 
   services.xserver.videoDrivers = lib.mkAfter [ "nvidia" ];
   boot.kernelModules = [ "kvm-intel" ];


### PR DESCRIPTION
## Summary
- add reusable Yoga desktop specialisation helpers for session and graphics profile overrides
- add docked and on-the-go variants for both `niri` and `plasma`
- switch NVIDIA prime offload vs sync mode automatically based on the selected specialisation