### PR TITLE
refactor: share ddroid session wrapper logic

### DIFF
--- a/bin/ddroid
+++ b/bin/ddroid
@@ -1,55 +1,19 @@
 #!/usr/bin/env bash
-#
-# droid-session-wrapper
-#
-# PURPOSE
-#   Wrapper around `droid` that persists the latest session id in a `.droid`
-#   file and automatically resumes it on subsequent runs.
-#
-# SESSION FILE RESOLUTION
-#   - If inside a git worktree:
-#       - On resume: searches for `.droid` starting in the current directory
-#         and walking up parent directories until the git repo root.
-#       - On save (default): writes to `<git-root>/.droid`.
-#   - If NOT inside a git worktree:
-#       - On resume: only checks `./.droid`.
-#       - On save: writes to `./.droid`.
-#
-# FLAGS
-#   -n
-#     Force a new session (ignores any discovered `.droid` on resume).
-#     Still saves the new session id to the default session file location:
-#       - git repo: `<git-root>/.droid`
-#       - non-git:  `./.droid`
-#
-#   -f
-#     Force session to be anchored in the current directory.
-#     Creates/overwrites `./.droid` with the new session id.
-#     Also implies `-n` (i.e. will not resume an existing session).
-#
-#   -r <session_id>
-#     Instructs droid to resume a specific session id (passed through as
-#     `-r <session_id>`). Also implies `-n` (no `.droid` auto-resume).
-#     The resulting session id emitted by droid (if any) is persisted per the
-#     save rules above (default or `-f`).
-#
-# USAGE
-#   droidw [-n] [-f] [-r session_id] [--] [droid_args...]
-#
-# EXIT CODES
-#   - Returns the exit code of the underlying `droid` invocation.
-#
-# NOTES
-#   - Session id extraction relies on matching stderr lines containing:
-#       `droid --resume <hex-and-dashes>`
-#   - The wrapper captures stderr to a temp file in order to parse the id.
 
 set -u
 
-# Constants
-readonly SESSION_PATTERN='droid --resume [a-f0-9-]*'
+if ! declare -F session_wrapper_find_file >/dev/null; then
+  session_wrapper_script_dir=$(
+    CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd
+  )
+  # shellcheck disable=SC1091
+  . "$session_wrapper_script_dir/lib/session-wrapper-common.sh"
+  unset session_wrapper_script_dir
+fi
 
-# Cleanup temporary files on exit
+readonly SESSION_PATTERN='droid --resume [a-f0-9-]*'
+readonly SESSION_FILE_NAME='.droid'
+
 cleanup() {
   local exit_code=$?
   [[ -n "${stderr_file:-}" && -f "$stderr_file" ]] && rm -f "$stderr_file"
@@ -58,31 +22,22 @@ cleanup() {
 trap cleanup EXIT
 
 display_usage() {
-  echo "\
-#################################################################################
-# Usage: $(basename "$0") [-n] [-f] [-r session_id] [--] [droid_args...]        #
-#                                                                               #
-# Wrapper for 'droid' that manages session persistence.                         #
-#                                                                               #
-# Options:                                                                      #
-#   -n              Force a new session (ignore existing .droid file)           #
-#   -f              Force session in current directory (create new .droid here) #
-#   -r session_id   Resume a specific session                                   #
-#   -h              Show this help and droid's help                             #
-#################################################################################
+  cat <<EOF
+Usage: $(basename "$0") [-n] [-f] [-r session_id] [--] [droid_args...]
+
+Resume the last saved droid session from .droid unless told to start fresh.
+
+Options:
+  -n              Ignore any saved session and start a new one
+  -f              Save the next session to ./.droid and do not auto-resume
+  -r session_id   Resume the given session id and skip .droid auto-resume
+  -h              Show this help and droid's help
 
 Original droid help:
-"
+EOF
   droid --help
 }
 
-# Extract session ID from stderr output
-# Arguments:
-#   $1: path to stderr capture file
-# Output:
-#   Prints session id to stdout
-# Returns:
-#   0 if session id extracted, 1 otherwise
 extract_session_id() {
   local stderr_file="$1"
 
@@ -91,96 +46,6 @@ extract_session_id() {
   fi
 
   grep -o "$SESSION_PATTERN" "$stderr_file" | sed 's/droid --resume //'
-}
-
-# Find a `.droid` file by searching parent directories.
-# Behavior:
-#   - In git repo: searches from $PWD up to git root (inclusive)
-#   - Not in git: checks only `$PWD/.droid`
-# Output:
-#   Prints the found `.droid` filepath to stdout
-# Returns:
-#   0 if found, 1 otherwise
-find_droid_file() {
-  local current_dir="$PWD"
-  local git_root
-  local search_limit=""
-
-  if git_root=$(git rev-parse --show-toplevel 2>/dev/null); then
-    search_limit="$git_root"
-  else
-    if [[ -f "$current_dir/.droid" ]]; then
-      echo "$current_dir/.droid"
-      return 0
-    fi
-    return 1
-  fi
-
-  while [[ "$current_dir" != "$search_limit" && "$current_dir" != "/" ]]; do
-    if [[ -f "$current_dir/.droid" ]]; then
-      echo "$current_dir/.droid"
-      return 0
-    fi
-    current_dir=$(dirname "$current_dir")
-  done
-
-  if [[ -f "$search_limit/.droid" ]]; then
-    echo "$search_limit/.droid"
-    return 0
-  fi
-
-  return 1
-}
-
-# Determine default session file path for saving.
-# Behavior:
-#   - In git repo: `<git-root>/.droid`
-#   - Not in git: `./.droid`
-# Output:
-#   Prints the default save path to stdout
-get_default_session_file_path() {
-  local git_root
-  if git_root=$(git rev-parse --show-toplevel 2>/dev/null); then
-    echo "$git_root/.droid"
-  else
-    echo "./.droid"
-  fi
-}
-
-# Save session id to a specific `.droid` file.
-# Arguments:
-#   $1: session id
-#   $2: session file path
-save_session_id() {
-  local session_id="$1"
-  local session_file="$2"
-  echo "$session_id" >"$session_file"
-}
-
-# Load session id from the discovered `.droid` file.
-# Behavior:
-#   - Uses find_droid_file() resolution rules.
-# Output:
-#   Prints session id to stdout
-# Returns:
-#   0 if loaded, 1 otherwise
-# Side-effects:
-#   - If `.droid` exists but is empty/whitespace, it is removed.
-load_session_id() {
-  local droid_file
-  if ! droid_file=$(find_droid_file); then
-    return 1
-  fi
-
-  local session_id
-  session_id=$(cat "$droid_file" | tr -d '[:space:]')
-
-  if [[ -z "$session_id" ]]; then
-    rm -f "$droid_file"
-    return 1
-  fi
-
-  echo "$session_id"
 }
 
 main() {
@@ -226,12 +91,12 @@ main() {
   # Where to persist a new session id (not where to resume from).
   local session_file
   if [[ "$force_current_dir" == true ]]; then
-    session_file="./.droid"
+    session_file="./$SESSION_FILE_NAME"
   else
-    session_file=$(get_default_session_file_path)
+    session_file=$(session_wrapper_default_file "$SESSION_FILE_NAME")
   fi
 
-  if [[ "$force_new_session" == false ]] && session_id=$(load_session_id); then
+  if [[ "$force_new_session" == false ]] && session_id=$(session_wrapper_load_id "$SESSION_FILE_NAME"); then
     echo "Resuming droid session: $session_id"
     droid --resume "$session_id" "${droid_args[@]}" 2>"$stderr_file"
   else
@@ -241,7 +106,7 @@ main() {
   local droid_exit_code=$?
 
   if new_session_id=$(extract_session_id "$stderr_file"); then
-    save_session_id "$new_session_id" "$session_file"
+    session_wrapper_save_id "$new_session_id" "$session_file"
     echo "Session ID saved to $session_file: $new_session_id" >&2
   fi
 

--- a/bin/ddroid
+++ b/bin/ddroid
@@ -20,7 +20,17 @@ if ! declare -F session_wrapper_find_file >/dev/null ||
     CDPATH='' cd -P -- "$(dirname -- "$session_wrapper_script_path")" && pwd -P
   )
   # shellcheck disable=SC1091
-  . "$session_wrapper_script_dir/lib/session-wrapper-common.sh"
+  if ! . "$session_wrapper_script_dir/lib/session-wrapper-common.sh"; then
+    echo "Failed to source session wrapper helpers from '$session_wrapper_script_dir/lib/session-wrapper-common.sh'" >&2
+    exit 1
+  fi
+  if ! declare -F session_wrapper_find_file >/dev/null ||
+    ! declare -F session_wrapper_default_file >/dev/null ||
+    ! declare -F session_wrapper_load_id >/dev/null ||
+    ! declare -F session_wrapper_save_id >/dev/null; then
+    echo "Missing required session wrapper helper(s) after sourcing common library" >&2
+    exit 1
+  fi
   unset session_wrapper_script_path
   unset session_wrapper_script_dir
 fi

--- a/bin/ddroid
+++ b/bin/ddroid
@@ -2,12 +2,26 @@
 
 set -u
 
-if ! declare -F session_wrapper_find_file >/dev/null; then
+if ! declare -F session_wrapper_find_file >/dev/null ||
+  ! declare -F session_wrapper_default_file >/dev/null ||
+  ! declare -F session_wrapper_load_id >/dev/null ||
+  ! declare -F session_wrapper_save_id >/dev/null; then
+  session_wrapper_script_path="${BASH_SOURCE[0]}"
+  while [[ -L "$session_wrapper_script_path" ]]; do
+    session_wrapper_script_dir=$(
+      CDPATH='' cd -P -- "$(dirname -- "$session_wrapper_script_path")" && pwd -P
+    )
+    session_wrapper_script_path=$(readlink -- "$session_wrapper_script_path")
+    if [[ "$session_wrapper_script_path" != /* ]]; then
+      session_wrapper_script_path="$session_wrapper_script_dir/$session_wrapper_script_path"
+    fi
+  done
   session_wrapper_script_dir=$(
-    CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd
+    CDPATH='' cd -P -- "$(dirname -- "$session_wrapper_script_path")" && pwd -P
   )
   # shellcheck disable=SC1091
   . "$session_wrapper_script_dir/lib/session-wrapper-common.sh"
+  unset session_wrapper_script_path
   unset session_wrapper_script_dir
 fi
 
@@ -25,12 +39,12 @@ display_usage() {
   cat <<EOF
 Usage: $(basename "$0") [-n] [-f] [-r session_id] [--] [droid_args...]
 
-Resume the last saved droid session from .droid unless told to start fresh.
+Resume the last saved droid session from $SESSION_FILE_NAME unless told to start fresh.
 
 Options:
   -n              Ignore any saved session and start a new one
-  -f              Save the next session to ./.droid and do not auto-resume
-  -r session_id   Resume the given session id and skip .droid auto-resume
+  -f              Save the next session to ./$SESSION_FILE_NAME and do not auto-resume
+  -r session_id   Resume the given session id and skip $SESSION_FILE_NAME auto-resume
   -h              Show this help and droid's help
 
 Original droid help:
@@ -107,7 +121,13 @@ main() {
 
   if new_session_id=$(extract_session_id "$stderr_file"); then
     session_wrapper_save_id "$new_session_id" "$session_file"
-    echo "Session ID saved to $session_file: $new_session_id" >&2
+    local save_exit_code=$?
+    if [[ "$save_exit_code" -eq 0 ]]; then
+      echo "Session ID saved to $session_file: $new_session_id" >&2
+    else
+      echo "Failed to save session ID '$new_session_id' to '$session_file'" >&2
+      return "$save_exit_code"
+    fi
   fi
 
   return $droid_exit_code

--- a/bin/lib/session-wrapper-common.sh
+++ b/bin/lib/session-wrapper-common.sh
@@ -67,7 +67,6 @@ session_wrapper_save_id() {
   # Validate session_id before creating or writing any files
   [[ -n "$session_id" ]] || return 1
   [[ "$session_id" != *$'\n'* ]] || return 1
-  [[ "$session_id" != *$'\0'* ]] || return 1
 
   session_dir=$(dirname -- "$session_file")
   session_base=$(basename -- "$session_file")


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized session file handling to use shared session helpers and a single default session filename; now falls back to a current-directory anchored file when appropriate and fails fast if helpers are unavailable.
* **Bug Fixes**
  * Improved save behavior: clear failure messages and proper error return when saving fails.
  * Relaxed session ID validation to accept a broader range of values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->