### PR TITLE
refactor: share ooc session wrapper logic

### DIFF
--- a/bin/ooc
+++ b/bin/ooc
@@ -1,51 +1,16 @@
 #!/usr/bin/env bash
-#
-# opencode-session-wrapper
-#
-# PURPOSE
-#   Wrapper around `opencode` that persists the latest session id in a `.ooc`
-#   file and automatically resumes it on subsequent runs.
-#
-# SESSION FILE RESOLUTION
-#   - If inside a git worktree:
-#       - On resume: searches for `.ooc` starting in the current directory
-#         and walking up parent directories until the git repo root.
-#       - On save (default): writes to `<git-root>/.ooc`.
-#   - If NOT inside a git worktree:
-#       - On resume: only checks `./.ooc`.
-#       - On save: writes to `./.ooc`.
-#
-# FLAGS
-#   -n
-#     Force a new session (ignores any discovered `.ooc` on resume).
-#     Still saves the new session id to the default session file location:
-#       - git repo: `<git-root>/.ooc`
-#       - non-git:  `./.ooc`
-#
-#   -f
-#     Force session to be anchored in the current directory.
-#     Creates/overwrites `./.ooc` with the new session id.
-#     Also implies `-n` (i.e. will not resume an existing session).
-#
-#   -s <session_id>
-#     Instructs opencode to resume a specific session id (passed through as
-#     `-s <session_id>`). Also implies `-n` (no `.ooc` auto-resume).
-#     The resulting session id emitted by opencode (if any) is persisted per the
-#     save rules above (default or `-f`).
-#
-# USAGE
-#   ooc [-n] [-f] [-s session_id] [--] [opencode_args...]
-#
-# EXIT CODES
-#   - Returns the exit code of the underlying `opencode` invocation.
-#
-# NOTES
-#   - Session id extraction relies on matching terminal output lines containing:
-#       `opencode -s ses_<id>`
 
 set -u
 
-# Constants
+if ! declare -F session_wrapper_find_file >/dev/null; then
+  session_wrapper_script_dir=$(
+    CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd
+  )
+  # shellcheck disable=SC1091
+  . "$session_wrapper_script_dir/lib/session-wrapper-common.sh"
+  unset session_wrapper_script_dir
+fi
+
 readonly SESSION_PATTERN='opencode -s ses_[A-Za-z0-9_-]*'
 readonly EXIT_MARKER='__OOC_EXIT_CODE__:'
 readonly SESSION_FILE_NAME='.ooc'
@@ -59,127 +24,28 @@ cleanup() {
 trap cleanup EXIT
 
 display_usage() {
-  echo "\
-#################################################################################
-# Usage: $(basename "$0") [-n] [-f] [-s session_id] [--] [opencode_args...]     #
-#                                                                               #
-# Wrapper for 'opencode' that manages session persistence.                      #
-#                                                                               #
-# Options:                                                                      #
-#   -n              Force a new session (ignore existing .ooc file)              #
-#   -f              Force session in current directory (create new .ooc here)    #
-#   -s session_id   Resume a specific session                                    #
-#   -h              Show this help and opencode's help                           #
-#################################################################################
+  cat <<EOF
+Usage: $(basename "$0") [-n] [-f] [-s session_id] [--] [opencode_args...]
+
+Resume the last saved opencode session from .ooc unless told to start fresh.
+
+Options:
+  -n              Ignore any saved session and start a new one
+  -f              Save the next session to ./.ooc and do not auto-resume
+  -s session_id   Resume the given session id and skip .ooc auto-resume
+  -h              Show this help and opencode's help
 
 Original opencode help:
-"
+EOF
   opencode --help
 }
 
-# Extract session ID from terminal transcript.
-# Arguments:
-#   $1: transcript file path
-# Output:
-#   Prints session id to stdout
-# Returns:
-#   0 if session id extracted, 1 otherwise
 extract_session_id() {
   local transcript_file="$1"
   local session_id
   session_id=$(grep -a -o "$SESSION_PATTERN" "$transcript_file" | sed 's/opencode -s //' | tail -n1)
 
   if [[ -z "$session_id" ]]; then
-    return 1
-  fi
-
-  echo "$session_id"
-}
-
-# Find a `.ooc` file by searching parent directories.
-# Behavior:
-#   - In git repo: searches from $PWD up to git root (inclusive)
-#   - Not in git: checks only `$PWD/.ooc`
-# Output:
-#   Prints the found `.ooc` filepath to stdout
-# Returns:
-#   0 if found, 1 otherwise
-find_ooc_file() {
-  local current_dir="$PWD"
-  local git_root
-  local search_limit=""
-
-  if git_root=$(git rev-parse --show-toplevel 2>/dev/null); then
-    search_limit="$git_root"
-  else
-    if [[ -f "$current_dir/$SESSION_FILE_NAME" ]]; then
-      echo "$current_dir/$SESSION_FILE_NAME"
-      return 0
-    fi
-    return 1
-  fi
-
-  while [[ "$current_dir" != "$search_limit" && "$current_dir" != "/" ]]; do
-    if [[ -f "$current_dir/$SESSION_FILE_NAME" ]]; then
-      echo "$current_dir/$SESSION_FILE_NAME"
-      return 0
-    fi
-    current_dir=$(dirname "$current_dir")
-  done
-
-  if [[ -f "$search_limit/$SESSION_FILE_NAME" ]]; then
-    echo "$search_limit/$SESSION_FILE_NAME"
-    return 0
-  fi
-
-  return 1
-}
-
-# Determine default session file path for saving.
-# Behavior:
-#   - In git repo: `<git-root>/.ooc`
-#   - Not in git: `./.ooc`
-# Output:
-#   Prints the default save path to stdout
-get_default_session_file_path() {
-  local git_root
-  if git_root=$(git rev-parse --show-toplevel 2>/dev/null); then
-    echo "$git_root/$SESSION_FILE_NAME"
-  else
-    echo "./$SESSION_FILE_NAME"
-  fi
-}
-
-# Save session id to a specific `.ooc` file.
-# Arguments:
-#   $1: session id
-#   $2: session file path
-save_session_id() {
-  local session_id="$1"
-  local session_file="$2"
-  echo "$session_id" >"$session_file"
-}
-
-# Load session id from the discovered `.ooc` file.
-# Behavior:
-#   - Uses find_ooc_file() resolution rules.
-# Output:
-#   Prints session id to stdout
-# Returns:
-#   0 if loaded, 1 otherwise
-# Side-effects:
-#   - If `.ooc` exists but is empty/whitespace, it is removed.
-load_session_id() {
-  local ooc_file
-  if ! ooc_file=$(find_ooc_file); then
-    return 1
-  fi
-
-  local session_id
-  session_id=$(cat "$ooc_file" | tr -d '[:space:]')
-
-  if [[ -z "$session_id" ]]; then
-    rm -f "$ooc_file"
     return 1
   fi
 
@@ -234,10 +100,10 @@ main() {
   if [[ "$force_current_dir" == true ]]; then
     session_file="./$SESSION_FILE_NAME"
   else
-    session_file=$(get_default_session_file_path)
+    session_file=$(session_wrapper_default_file "$SESSION_FILE_NAME")
   fi
 
-  if [[ "$force_new_session" == false ]] && session_id=$(load_session_id); then
+  if [[ "$force_new_session" == false ]] && session_id=$(session_wrapper_load_id "$SESSION_FILE_NAME"); then
     echo "Resuming opencode session: $session_id"
     opencode_exec_args=("-s" "$session_id" "${opencode_args[@]}")
   else
@@ -280,7 +146,7 @@ EOF
   fi
 
   if new_session_id=$(extract_session_id "$transcript_file"); then
-    save_session_id "$new_session_id" "$session_file"
+    session_wrapper_save_id "$new_session_id" "$session_file"
     echo "Session ID saved to $session_file: $new_session_id" >&2
   fi
 

--- a/bin/ooc
+++ b/bin/ooc
@@ -147,7 +147,13 @@ EOF
 
   if new_session_id=$(extract_session_id "$transcript_file"); then
     session_wrapper_save_id "$new_session_id" "$session_file"
-    echo "Session ID saved to $session_file: $new_session_id" >&2
+    local save_exit_code=$?
+    if [[ "$save_exit_code" -eq 0 ]]; then
+      echo "Session ID saved to $session_file: $new_session_id" >&2
+    else
+      echo "Failed to save session ID '$new_session_id' to '$session_file'" >&2
+      return "$save_exit_code"
+    fi
   fi
 
   return "$opencode_exit_code"

--- a/home/modules/package-sets.nix
+++ b/home/modules/package-sets.nix
@@ -147,7 +147,10 @@
         pkgs.opencode
         pkgs.util-linux
       ];
-      text = builtins.readFile ../../bin/ooc;
+      text = lib.concatStringsSep "\n" [
+        (builtins.readFile ../../bin/lib/session-wrapper-common.sh)
+        (builtins.readFile ../../bin/ooc)
+      ];
     })
     (pkgs.writeShellApplication {
       name = "docker-compose-deps";


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated session discovery/loading/saving into a shared helper to streamline internal session management.

* **Bug Fixes / UX**
  * Saving a discovered session now reports success only on successful save and shows a clear failure message on error.
  * Usage output simplified to a shorter description while preserving the original detailed help display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->