### PR TITLE
fix(niri): route portals to working backends

### DIFF
--- a/dotfiles/niri/config.kdl
+++ b/dotfiles/niri/config.kdl
@@ -371,24 +371,6 @@ window-rule {
 }
 
 
-# // Enable blur behind the Alacritty terminal.
-# window-rule {
-#     match app-id="^com.mitchellh.ghostty$"
-
-#     background-effect {
-#         blur true
-#     }
-# }
-
-# // Enable blur behind the fuzzel launcher.
-# layer-rule {
-#     match namespace="^launcher$"
-
-#     background-effect {
-#         blur true
-#     }
-# }
-
 binds {
     // Keys consist of modifiers separated by + signs, followed by an XKB key name
     // in the end. To find an XKB name for a particular key, you may use a program

--- a/flake.lock
+++ b/flake.lock
@@ -171,11 +171,11 @@
         "uv2nix": "uv2nix_2"
       },
       "locked": {
-        "lastModified": 1777286319,
-        "narHash": "sha256-diw+XfOZo1gjbO61LAnXkCYuUQMMdAxK+VR99wCTe/A=",
+        "lastModified": 1777367528,
+        "narHash": "sha256-bperxTnqSQIPp7nSkKMx7luAYzvoF+Ql+6MomC163fA=",
         "owner": "NousResearch",
         "repo": "hermes-agent",
-        "rev": "65f648ee84ff97a90fd43d85e521a7100c6a999d",
+        "rev": "bd10acd747c12e2a793d2743e04462bf82d481b5",
         "type": "github"
       },
       "original": {
@@ -191,11 +191,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777258755,
-        "narHash": "sha256-EC07KwADRE2LdIk7vEDyAaD3I0ZUq24T9jQF9L0iEPk=",
+        "lastModified": 1777349711,
+        "narHash": "sha256-PGKgo2dO6fK603QGI+DWXdKmS09pbJjjTxwRHdhkGZA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7f8bbc93d63401e41368d6ddc46a4f631610fa90",
+        "rev": "c1140540536d483e2730320100f6835d62c94fdf",
         "type": "github"
       },
       "original": {
@@ -455,11 +455,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776422828,
-        "narHash": "sha256-tEyCGYk4UAbtFBCPNEs0VJHqo5tHRECaO21BzfaKX3M=",
+        "lastModified": 1777279293,
+        "narHash": "sha256-qXXkUJ6wee7BGrH5Scd+iNHLOlmHw382XAoZaK+WF4A=",
         "owner": "jakob1379",
         "repo": "t3code-flake",
-        "rev": "c07ef94436a3056cd2bb6751e7ce522a315b04db",
+        "rev": "ca00c91c727fa6b98cb621571a57f70572984e5c",
         "type": "github"
       },
       "original": {
@@ -561,11 +561,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1776862505,
-        "narHash": "sha256-w+WE/bGbwBq+Y6EGBMFwpMg0bVS8B6HGXX9qAJvm1Vs=",
+        "lastModified": 1777298815,
+        "narHash": "sha256-SlRJTEPtyE++oLFgcfM5LJlXVCv/DirHFVSZfIozxkE=",
         "owner": "jakob1379",
         "repo": "waytorandr",
-        "rev": "db53172a835fb77540dac4f91f0742d10ec22556",
+        "rev": "4a949184e9b8b6638495ef661b617cb0900e4f6f",
         "type": "github"
       },
       "original": {
@@ -581,11 +581,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777092705,
-        "narHash": "sha256-qKMvM2+eKusg6H6lG2bwDdFjNi1XfEjdLD5xIt8ZgFs=",
+        "lastModified": 1777352968,
+        "narHash": "sha256-BZ+BHCINHSyyCOWo4pCJQU4T994iZLiw7lgFMNw+W9k=",
         "owner": "youwen5",
         "repo": "zen-browser-flake",
-        "rev": "10f5c809db4f8e7badb6d505924ebbaaeefda4e4",
+        "rev": "bebce586893c7d441edd6cf9cf2cf62a1799361e",
         "type": "github"
       },
       "original": {

--- a/home/modules/programs.nix
+++ b/home/modules/programs.nix
@@ -704,6 +704,14 @@ in
             '';
           };
         };
+        mimeApps = {
+          enable = true;
+          defaultApplications = {
+            "application/x-directory" = [ "org.kde.dolphin.desktop" ];
+            "inode/directory" = [ "org.kde.dolphin.desktop" ];
+            "x-scheme-handler/file" = [ "org.kde.dolphin.desktop" ];
+          };
+        };
         terminal-exec = {
           enable = true;
           settings.default = [ "com.mitchellh.ghostty.desktop" ];

--- a/home/modules/programs.nix
+++ b/home/modules/programs.nix
@@ -269,7 +269,7 @@ in
             background-opacity = 0.85;
             bold-is-bright = true;
             clipboard-paste-protection = false;
-            confirm-close-surface = false;
+            confirm-close-surface = true;
             copy-on-select = "clipboard";
             cursor-style = "block";
             cursor-style-blink = false;

--- a/home/systems/seeq.nix
+++ b/home/systems/seeq.nix
@@ -28,7 +28,6 @@
   };
 
   home = {
-    shellAliases.ec = ''emacsclient -t --alternate-editor ""'';
     sessionVariables = {
       EDITOR = "emacsclient -t";
       VISUAL = "emacsclient -t";

--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -177,7 +177,11 @@
   };
 
   # Programs commonly used
-  programs.niri.enable = true;
+  programs.niri = {
+    enable = true;
+    useNautilus = false;
+  };
+  xdg.portal.config.niri."org.freedesktop.impl.portal.Secret" = lib.mkForce "kwallet";
   services.clamav = {
     daemon.enable = true;
     updater.enable = true;

--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -177,11 +177,12 @@
   };
 
   # Programs commonly used
+  services.iio-niri.enable = true;
   programs.niri = {
     enable = true;
     useNautilus = false;
   };
-  xdg.portal.config.niri."org.freedesktop.impl.portal.Secret" = lib.mkForce "kwallet";
+
   services.clamav = {
     daemon.enable = true;
     updater.enable = true;


### PR DESCRIPTION
## Summary
- use GTK for niri file chooser dialogs instead of the GNOME/Nautilus portal path
- route niri Secret portal to kwallet, matching the enabled Plasma/KWallet setup
- leave Plasma's KDE portal config available via the existing Plasma config package

## Verification
- nix fmt
- nix develop -c nix flake check --allow-import-from-derivation
- nix build .#t3code
- nix build .#nixosConfigurations.amd.config.system.build.toplevel
- verified result/etc/xdg/xdg-desktop-portal/niri-portals.conf contains FileChooser=gtk and Secret=kwallet
- verified result/sw/share/xdg-desktop-portal/kde-portals.conf still uses KDE/kwallet for Plasma

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Niri remains enabled; Nautilus integration disabled
  * New imaging service for Niri hardware enabled
  * Default file/URI handlers set to open with Dolphin
  * Ghostty now asks to confirm on close
  * Removed a convenience shell alias for launching Emacs (editor env vars unchanged)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->