### PR TITLE
feat(emacs): run ty and ruff through eglot

### DIFF
--- a/dotfiles/emacs/config.org
+++ b/dotfiles/emacs/config.org
@@ -934,7 +934,7 @@ Eglot replaces the lsp-mode stack and uses native Emacs interfaces: CAPF for Cor
    (latex-mode . eglot-ensure)
    (markdown-mode . eglot-ensure)
    (nix-mode . eglot-ensure)
-   (python-mode . eglot-ensure)
+   (python-base-mode . eglot-ensure)
    (sh-mode . eglot-ensure)
    (toml-mode . eglot-ensure)
    (typst-mode . eglot-ensure)
@@ -960,7 +960,12 @@ Eglot replaces the lsp-mode stack and uses native Emacs interfaces: CAPF for Cor
              (typescript-mode . ("vtsls" "--stdio"))
              (nix-mode . ("nixd"))
              (markdown-mode . ("marksman" "server"))
-             (python-mode . ("sh" "-c" "uv run --with ty ty server || uvx ty server"))))
+             (python-base-mode . ("uv" "run"
+                                  "--with" "git+https://github.com/mbaranchik/lsp-multi@73f66d1d23449d333a2ab9cd3ebdbbfd627ef127"
+                                  "lsp-multi"
+                                  "--lsp" "uv run --with ty ty server"
+                                  "--lsp" "uv run --with ruff ruff server"
+                                  "--error-timeout" "2"))))
     (add-to-list 'eglot-server-programs server))
   (add-to-list 'eglot-server-programs '(yaml-mode . ("yaml-language-server" "--stdio"))))
 #+END_SRC

--- a/dotfiles/emacs/config.org
+++ b/dotfiles/emacs/config.org
@@ -960,12 +960,9 @@ Eglot replaces the lsp-mode stack and uses native Emacs interfaces: CAPF for Cor
              (typescript-mode . ("vtsls" "--stdio"))
              (nix-mode . ("nixd"))
              (markdown-mode . ("marksman" "server"))
-             (python-base-mode . ("uv" "run"
-                                  "--with" "git+https://github.com/mbaranchik/lsp-multi@73f66d1d23449d333a2ab9cd3ebdbbfd627ef127"
-                                  "lsp-multi"
-                                  "--lsp" "uv run --with ty ty server"
-                                  "--lsp" "uv run --with ruff ruff server"
-                                  "--error-timeout" "2"))))
+             (python-base-mode . ("rass"
+                                  "--" "uv" "run" "--with" "ty" "ty" "server"
+                                  "--" "uv" "run" "--with" "ruff" "ruff" "server"))))
     (add-to-list 'eglot-server-programs server))
   (add-to-list 'eglot-server-programs '(yaml-mode . ("yaml-language-server" "--stdio"))))
 #+END_SRC

--- a/home/modules/package-sets.nix
+++ b/home/modules/package-sets.nix
@@ -98,6 +98,7 @@
     nixd
     powershell
     python3
+    rassumfrassum
     silver-searcher
     taplo
     texlab


### PR DESCRIPTION
## Summary
- switch Python Eglot hook to python-base-mode so python-mode and python-ts-mode are covered
- run Python Eglot through upstream-recommended Rassumfrassum (rass) so ty and Ruff can both serve the buffer
- bundle rassumfrassum from nixpkgs with the Emacs package set
- keep ty and Ruff project-sensitive by launching them with uv run --with instead of adding project dependencies

## Test Plan
- uv run --with rassumfrassum --with ty --with ruff rass --version
- nix develop -c nix eval --impure --raw --expr 'let flake = builtins.getFlake "git+file:///home/jsg/.config/home-manager"; in flake.inputs.nixpkgs.legacyPackages.x86_64-linux.rassumfrassum.version'
- nix develop -c emacs --batch -Q --eval '<read tangled config forms>'
- nix develop -c emacs --batch -Q --eval '<verify eglot lookup for python-mode resolves to rass command after requiring python>'
- nix develop -c prek run --files dotfiles/emacs/config.org home/modules/package-sets.nix
- nix develop -c nix flake check --no-build