### PR TITLE
[codex] home: prebuild switches with nix-fast-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,22 @@ Useful commands:
 ```bash
 nix fmt
 nix flake show
+hs
+hsu
+update-all
 ```
+
+`hs` switches the current user's Home Manager profile for the current host.
+`hsu` updates the flake first, then switches the same profile. `update-all`
+updates channels and the flake, switches Home Manager, runs user tool updates,
+and switches the current NixOS host.
+
+The switch helpers use `nix-fast-build` to prebuild exact flake outputs before
+activation. They intentionally avoid broad targets like `.#`, because recursive
+flake traversal can enter non-buildable input functions. Override the inferred
+targets with `HM_TARGET=user@host` or `NIXOS_TARGET=host`, tune parallelism with
+`NIX_FAST_BUILD_JOBS`, or set `NIX_FAST_BUILD_DISABLE=1` to use the direct
+`home-manager` / `nixos-rebuild` paths.
 
 ## Layout
 

--- a/bin/hm-switch
+++ b/bin/hm-switch
@@ -3,5 +3,41 @@ set -euo pipefail
 
 flakePath="${XDG_CONFIG_HOME:-$HOME/.config}/home-manager"
 
-# Run home-manager switch and pipe output to nom (nix-output-monitor)
-home-manager switch --flake "$flakePath" "$@" 2>&1 | nom
+host="${HOSTNAME:-$(uname -n)}"
+host="${host%%.*}"
+hmTarget="${HM_TARGET:-${USER}@${host}}"
+
+fastBuildJobs() {
+  if [[ -n "${NIX_FAST_BUILD_JOBS:-}" ]]; then
+    printf '%s\n' "$NIX_FAST_BUILD_JOBS"
+    return
+  fi
+
+  cores="$(nproc 2>/dev/null || printf '2')"
+  jobs=$((cores / 2))
+  if ((jobs < 1)); then
+    jobs=1
+  fi
+  printf '%s\n' "$jobs"
+}
+
+shouldFastBuild() {
+  [[ "${NIX_FAST_BUILD_DISABLE:-}" != 1 ]] || return 1
+
+  for arg in "$@"; do
+    case "$arg" in
+      --rollback | -n | --help | -h)
+        return 1
+        ;;
+    esac
+  done
+}
+
+if shouldFastBuild "$@"; then
+  nix-fast-build \
+    --flake "${flakePath}#homeConfigurations.\"${hmTarget}\".activationPackage" \
+    --no-link \
+    -j "$(fastBuildJobs)"
+fi
+
+home-manager switch --flake "${flakePath}#${hmTarget}" "$@" 2>&1 | nom

--- a/bin/hm-switch-update
+++ b/bin/hm-switch-update
@@ -3,6 +3,10 @@ set -euo pipefail
 
 flakePath="${XDG_CONFIG_HOME:-$HOME/.config}/home-manager"
 
+host="${HOSTNAME:-$(uname -n)}"
+host="${host%%.*}"
+hmTarget="${HM_TARGET:-${USER}@${host}}"
+
 if command -v gh >/dev/null 2>&1 && [[ "${NIX_CONFIG:-}" != *"access-tokens"* ]]; then
   githubToken="$(gh auth token -h github.com 2>/dev/null || true)"
   if [[ -n "$githubToken" ]]; then
@@ -10,4 +14,39 @@ if command -v gh >/dev/null 2>&1 && [[ "${NIX_CONFIG:-}" != *"access-tokens"* ]]
   fi
 fi
 
-nix flake update --flake "$flakePath" && home-manager switch --flake "$flakePath" "$@" 2>&1 | nom
+fastBuildJobs() {
+  if [[ -n "${NIX_FAST_BUILD_JOBS:-}" ]]; then
+    printf '%s\n' "$NIX_FAST_BUILD_JOBS"
+    return
+  fi
+
+  cores="$(nproc 2>/dev/null || printf '2')"
+  jobs=$((cores / 2))
+  if ((jobs < 1)); then
+    jobs=1
+  fi
+  printf '%s\n' "$jobs"
+}
+
+shouldFastBuild() {
+  [[ "${NIX_FAST_BUILD_DISABLE:-}" != 1 ]] || return 1
+
+  for arg in "$@"; do
+    case "$arg" in
+      --rollback | -n | --help | -h)
+        return 1
+        ;;
+    esac
+  done
+}
+
+nix flake update --flake "$flakePath"
+
+if shouldFastBuild "$@"; then
+  nix-fast-build \
+    --flake "${flakePath}#homeConfigurations.\"${hmTarget}\".activationPackage" \
+    --no-link \
+    -j "$(fastBuildJobs)"
+fi
+
+home-manager switch --flake "${flakePath}#${hmTarget}" "$@" 2>&1 | nom

--- a/bin/update-all
+++ b/bin/update-all
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 flakePath="${XDG_CONFIG_HOME:-$HOME/.config}/home-manager"
+host="${HOSTNAME:-$(uname -n)}"
+host="${host%%.*}"
+hmTarget="${HM_TARGET:-${USER}@${host}}"
+nixosTarget="${NIXOS_TARGET:-${host}}"
 
 if command -v gh >/dev/null 2>&1 && [[ "${NIX_CONFIG:-}" != *"access-tokens"* ]]; then
   githubToken="$(gh auth token -h github.com 2>/dev/null || true)"
@@ -9,14 +14,39 @@ if command -v gh >/dev/null 2>&1 && [[ "${NIX_CONFIG:-}" != *"access-tokens"* ]]
   fi
 fi
 
+fastBuildJobs() {
+  if [[ -n "${NIX_FAST_BUILD_JOBS:-}" ]]; then
+    printf '%s\n' "$NIX_FAST_BUILD_JOBS"
+    return
+  fi
+
+  cores="$(nproc 2>/dev/null || printf '2')"
+  jobs=$((cores / 2))
+  if ((jobs < 1)); then
+    jobs=1
+  fi
+  printf '%s\n' "$jobs"
+}
+
+fastBuildEnabled() {
+  [[ "${NIX_FAST_BUILD_DISABLE:-}" != 1 ]]
+}
+
 # Parallel updates
 sudo -v
 sudo nix-channel --update &
 nix flake update --flake "${flakePath}" &
 nix-channel --update &
 wait
+
 # Home Manager switch with output monitor
-home-manager switch --flake "${flakePath}" "$@" |& nom
+if fastBuildEnabled; then
+  nix-fast-build \
+    --flake "${flakePath}#homeConfigurations.\"${hmTarget}\".activationPackage" \
+    --no-link \
+    -j "$(fastBuildJobs)"
+fi
+home-manager switch --flake "${flakePath}#${hmTarget}" "$@" |& nom
 
 uv tool upgrade --all &
 rm -rf ~/.cache/opencode
@@ -26,4 +56,16 @@ wait
 
 # NixOS switch with output monitor
 sudo -v
-nixos-rebuild switch --sudo --flake "${flakePath}" |& nom
+if fastBuildEnabled; then
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' EXIT
+
+  nix-fast-build \
+    --flake "${flakePath}#nixosConfigurations.\"${nixosTarget}\".config.system.build.toplevel" \
+    --out-link "$tmpdir/nixos-system" \
+    -j "$(fastBuildJobs)"
+
+  nixos-rebuild switch --sudo --store-path "$(readlink -f "$tmpdir/nixos-system")" |& nom
+else
+  nixos-rebuild switch --sudo --flake "${flakePath}#${nixosTarget}" |& nom
+fi

--- a/flake.lock
+++ b/flake.lock
@@ -284,7 +284,7 @@
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/home/modules/package-sets.nix
+++ b/home/modules/package-sets.nix
@@ -186,7 +186,10 @@
     (pkgs.writeShellApplication {
       name = "hs";
       runtimeInputs = [
+        pkgs.coreutils
         pkgs.home-manager
+        pkgs.nix-eval-jobs
+        pkgs.nix-fast-build
         pkgs.nix-output-monitor
       ];
       text = builtins.readFile ../../bin/hm-switch;
@@ -194,8 +197,11 @@
     (pkgs.writeShellApplication {
       name = "hsu";
       runtimeInputs = [
+        pkgs.coreutils
         pkgs.gh
         pkgs.home-manager
+        pkgs.nix-eval-jobs
+        pkgs.nix-fast-build
         pkgs.nix-output-monitor
       ];
       text = builtins.readFile ../../bin/hm-switch-update;
@@ -224,8 +230,11 @@
     (pkgs.writeShellApplication {
       name = "update-all";
       runtimeInputs = [
+        pkgs.coreutils
         pkgs.gh
         pkgs.home-manager
+        pkgs.nix-eval-jobs
+        pkgs.nix-fast-build
         pkgs.nix-output-monitor
         pkgs.uv
       ];


### PR DESCRIPTION
## Summary

Adds `nix-fast-build` prebuild steps to the local switch helpers instead of asking it to recurse over the whole flake.

- `hs` and `hsu` now prebuild `homeConfigurations."$HM_TARGET".activationPackage` before running `home-manager switch`.
- `update-all` now prebuilds both the Home Manager activation package and the NixOS system toplevel, then activates the NixOS result with `nixos-rebuild --store-path`.
- The wrapper packages now include `nix-fast-build` and `nix-eval-jobs` in their runtime inputs.
- README documents `hs`, `hsu`, `update-all`, `HM_TARGET`, `NIXOS_TARGET`, `NIX_FAST_BUILD_JOBS`, and `NIX_FAST_BUILD_DISABLE=1`.

## Why

`nix-fast-build -f .#` recursively evaluates broad flake outputs. In this repo that walks into non-buildable function values from inputs such as `flake-utils`, producing errors like missing `drv` or `name` arguments. The wrappers now target the concrete derivations that `home-manager switch` and `nixos-rebuild switch` actually need.

The `flake.lock` change only aligns the recorded `nixpkgs` original ref with `flake.nix` (`nixos-unstable`). Without that metadata alignment, pure Nix evaluation tried to update the unlocked `nixpkgs` input.

## Validation

- `bash -n bin/hm-switch bin/hm-switch-update bin/update-all`
- `git diff --check`
- `nix eval --no-write-lock-file --raw '.#homeConfigurations."jsg@amd".activationPackage.drvPath'`
- `nix eval --no-write-lock-file --raw '.#nixosConfigurations.amd.config.system.build.toplevel.drvPath'`

I also started `nix-fast-build --flake '.#homeConfigurations."jsg@amd".activationPackage' --no-link -j 1` via `nix shell`; it got past evaluation into the actual build graph. I stopped it because the full Home Manager closure build was long-running and not needed for this PR validation.