### PR TITLE
[codex] fix niri Vicinae launch shortcuts

### DIFF
--- a/dotfiles/niri/config.kdl
+++ b/dotfiles/niri/config.kdl
@@ -410,9 +410,9 @@ binds {
     Mod+Shift+Return hotkey-overlay-title="Open Terminal Below" { spawn-sh "before=\"$(niri msg -j windows)\"; niri msg action spawn -- xdg-terminal-exec; i=0; while [ \"$i\" -lt 40 ]; do new_id=\"$(niri msg -j windows | jq -r --argjson b \"$before\" '([.[].id] - ($b | map(.id))) | .[0] // empty')\"; [ -n \"$new_id\" ] && { niri msg action consume-or-expel-window-left --id \"$new_id\"; break; }; i=$((i + 1)); sleep 0.05; done"; }
     Mod+D hotkey-overlay-title="Run an Application: Vicinae" { spawn "vicinae" "vicinae://toggle"; }
     Mod+Shift+D hotkey-overlay-title="Open Launcher Root: Vicinae" { spawn "vicinae" "vicinae://open?popToRoot=true"; }
-    Mod+Shift+V hotkey-overlay-title="Open Clipboard History: Vicinae" { spawn "vicinae" "vicinae://extensions/vicinae/clipboard/history"; }
-    Mod+Shift+W hotkey-overlay-title="Open Window Switcher: Vicinae" { spawn "vicinae" "vicinae://extensions/vicinae/wm/switch-windows"; }
-    Mod+Period hotkey-overlay-title="Open Emoji Picker: Vicinae" { spawn "vicinae" "vicinae://extensions/vicinae/core/search-emojis"; }
+    Mod+Shift+V hotkey-overlay-title="Open Clipboard History: Vicinae" { spawn "vicinae" "vicinae://launch/clipboard/history"; }
+    Mod+Shift+W hotkey-overlay-title="Open Window Switcher: Vicinae" { spawn "vicinae" "vicinae://launch/wm/switch-windows"; }
+    Mod+Period hotkey-overlay-title="Open Emoji Picker: Vicinae" { spawn "vicinae" "vicinae://launch/core/search-emojis"; }
     Mod+B hotkey-overlay-title="Cycle Power Profile" { spawn "/home/jsg/.nix-profile/bin/noctalia-shell" "ipc" "call" "powerProfile" "cycle"; }
     Super+P hotkey-overlay-title="Display Mode" { spawn "display-mode-picker" "cycle"; }
     XF86Display hotkey-overlay-title="Display Mode" { spawn "display-mode-picker" "cycle"; }


### PR DESCRIPTION
## Summary

Updates the Niri Vicinae keybindings to use the current `vicinae://launch/...` URI shape for clipboard history, window switching, and emoji search.

## Validation

- `git diff --check`
- `nix eval --no-write-lock-file --raw '.#homeConfigurations."jsg@amd".activationPackage.type'`

The Nix eval completed successfully and returned `derivation`. It emitted the existing lock-file warning about `nixpkgs` wanting to refresh because this branch is based on `main`, not the separate nix-fast-build lock metadata PR.