### PR TITLE
[codex] add ag bash completion

### DIFF
--- a/home/modules/dotfiles.nix
+++ b/home/modules/dotfiles.nix
@@ -43,6 +43,13 @@
           (lib.mkIf cfg.enableEmacs cfg.emacs)
           (lib.mkIf cfg.enableMediaControl cfg.mediaControl)
           {
+            ".local/share/bash-completion/completions/ag".text = ''
+              _split_longopt() {
+                  _comp__split_longopt "$@"
+              }
+
+              . "${pkgs.silver-searcher}/share/bash-completion/completions/ag.bashcomp.sh"
+            '';
             ".local/share/bash-completion/completions/noctalia-shell".source =
               ../../scripts/completions/noctalia-shell-completions.sh;
             ".config/niri/config.kdl".source = ../../dotfiles/niri/config.kdl;


### PR DESCRIPTION
## Summary

Adds the Silver Searcher bash completion through the Home Manager dotfiles module, including the `_split_longopt` shim expected by the packaged completion script.

## Validation

- `git diff --check`
- `nix eval --no-write-lock-file --raw '.#homeConfigurations."jsg@amd".activationPackage.type'`

The Nix eval completed successfully and returned `derivation`. It emitted the existing lock-file warning about `nixpkgs` wanting to refresh because this branch is based on `main`, not the separate nix-fast-build lock metadata PR.