### PR TITLE
[codex] add CodeRabbit CLI package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,74 @@
     "agent-browser-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778716112,
-        "narHash": "sha256-DgHQRQXnaJ76pqehSASVEbCH/ch5b7z6u+U/1ro9O1Q=",
+        "lastModified": 1779302744,
+        "narHash": "sha256-4q3McZ0IbZPKC1GhaKAAfONjsdN1UX0GIMlmyl532L8=",
         "owner": "vercel-labs",
         "repo": "agent-browser",
-        "rev": "55f38f4d81981f0191c730005c419958c7d20605",
+        "rev": "4ad284890cb59564af603e6de403dd75dd19e832",
         "type": "github"
       },
       "original": {
         "owner": "vercel-labs",
         "repo": "agent-browser",
+        "type": "github"
+      }
+    },
+    "blueprint": {
+      "inputs": {
+        "nixpkgs": [
+          "numtide-llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "numtide-llm-agents",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776249299,
+        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": [
+          "numtide-llm-agents",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "numtide-llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "numtide-llm-agents",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "numtide-llm-agents",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778446047,
+        "narHash": "sha256-oQvcadh2BCkrog+SGrG6YffKJrveYpjj3TdQJWaKhaM=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "f2bc12af1a6369648aac41041ceeaa0b866599c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
         "type": "github"
       }
     },
@@ -61,6 +119,27 @@
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "numtide-llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -208,11 +287,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778839998,
-        "narHash": "sha256-RDgpRW/09hQMy2w+IAyS4M5lHJ24hvVQ9J4TY4m+7zc=",
+        "lastModified": 1779592288,
+        "narHash": "sha256-pVZwRFVFdHS3D3G07MiZQcSPENnv1xlYCJtfabkqd3Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3e707f5f93d7be40fd3e4182ed977446bdf2e2c3",
+        "rev": "23703a32ef3d7803a2f1bb9909a3f46fc5185e37",
         "type": "github"
       },
       "original": {
@@ -260,11 +339,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778393439,
-        "narHash": "sha256-mOtQxUjtKaPHLeoLOY/YEDctmud1X9KwJr4kE1MJ3Wc=",
+        "lastModified": 1779604987,
+        "narHash": "sha256-ZQ5z+fVhxYKtIFwtqGp5O0PD84BM1riASvqDaN5Xs+s=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "01466c414c7357ae2ce32be4a272a7c69e94ab5f",
+        "rev": "8fba98c80b48fa013820e0163c5096922fea4ddd",
         "type": "github"
       },
       "original": {
@@ -275,16 +354,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778762200,
-        "narHash": "sha256-NiOfW9nHPaDebfu3svLnJbljIMQgkEQnkm3orhePHPY=",
+        "lastModified": 1779508470,
+        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "27198194e52129ccd8e845e7d5911911e7fea7d7",
+        "rev": "29916453413845e54a65b8a1cf996842300cd299",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -310,14 +389,39 @@
         "type": "github"
       }
     },
+    "numtide-llm-agents": {
+      "inputs": {
+        "blueprint": "blueprint",
+        "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_2",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1779600478,
+        "narHash": "sha256-lDqdFwabA2Z2hlN7QoScaK1iAVYZCkSHqvSDRL714TM=",
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "rev": "c063ac9d0996bacacd6d79c0088c513002846ff4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "type": "github"
+      }
+    },
     "oh-my-opencode-slim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778842114,
-        "narHash": "sha256-8E9pwyXtkKqXPYdz36DiYpKitHwX4xxH9RrrAcchrwI=",
+        "lastModified": 1779598877,
+        "narHash": "sha256-gfwgtlKuN0bBXkp6ck43aBaH3bgDusnBKp2pNG18Xbo=",
         "owner": "alvinunreal",
         "repo": "oh-my-opencode-slim",
-        "rev": "af282e96e71d7ea531d413a41a5db844e7b62e27",
+        "rev": "cca59117099fa495fde92b9f9be795d79c19e0b8",
         "type": "github"
       },
       "original": {
@@ -425,6 +529,7 @@
         "navi-tldr-pages-src": "navi-tldr-pages-src",
         "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs",
+        "numtide-llm-agents": "numtide-llm-agents",
         "oh-my-opencode-slim-src": "oh-my-opencode-slim-src",
         "t3code-flake": "t3code-flake",
         "waytorandr": "waytorandr",
@@ -482,6 +587,21 @@
         "type": "github"
       }
     },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "t3code-flake": {
       "inputs": {
         "nixpkgs": [
@@ -489,11 +609,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778741252,
-        "narHash": "sha256-vT0H+y9dqxmWRCcaSV2E/oDqDaRVg6Oqs5Lzf3hLQcA=",
+        "lastModified": 1779170372,
+        "narHash": "sha256-elTjJXlrXusH2r9U8yG6+xSnSpDINzXsnn6848dOhpY=",
         "owner": "jakob1379",
         "repo": "t3code-flake",
-        "rev": "2fcf3bf4b9324db3784aa59c5d269bc83f5d7e26",
+        "rev": "dedd8afb81cf889a0a1a4eccaa275b502b21b800",
         "type": "github"
       },
       "original": {
@@ -502,9 +622,30 @@
         "type": "github"
       }
     },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "numtide-llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
     "utils": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -579,11 +720,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1778566552,
-        "narHash": "sha256-tTmh6cffPYCGs4lD8fXkpHn3fLo3Ws2cWKmjUY4f/4w=",
+        "lastModified": 1779514621,
+        "narHash": "sha256-KYJdk11QRMRuj4Dq9iyIUMGzCKIDK2ykJtpmrjKcZ3s=",
         "owner": "jakob1379",
         "repo": "waytorandr",
-        "rev": "ba8280c93388ea23f1f37fe03abd016354b35a96",
+        "rev": "44e546595f125868bff009c2fec4a5a609041dfd",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,10 @@
       url = "github:NousResearch/hermes-agent/265bd59c1d9f8dea658f243b257d4fae3685af53";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    numtide-llm-agents = {
+      url = "github:numtide/llm-agents.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     navi-cheats-src = {
       url = "github:denisidoro/cheats";
       flake = false;

--- a/home/systems/amd.nix
+++ b/home/systems/amd.nix
@@ -16,6 +16,7 @@ let
       ;
   };
 
+  coderabbit-cli = inputs.numtide-llm-agents.packages.${system}.coderabbit-cli;
   hermesAgent = inputs.hermes-agent.packages.${system}.default;
   hermesAgentWithEspeak = pkgs.symlinkJoin {
     name = "hermes-agent-with-espeak-ng";
@@ -57,6 +58,7 @@ in
       adw-gtk3
       glab
       hermesAgentWithEspeak
+      coderabbit-cli
       # teams-for-linux
       kdePackages.qt6ct
       libsForQt5.qt5ct


### PR DESCRIPTION
## Summary

Adds `numtide/llm-agents.nix` as a flake input and installs its `coderabbit-cli` package on the `amd` Home Manager profile.

This PR also carries the lock-file refresh produced with that input present, and aligns the locked `nixpkgs` original ref with `flake.nix` (`nixos-unstable`) so pure eval does not try to rewrite the lock.

## Validation

- `git diff --check`
- `nix eval --no-write-lock-file --raw '.#homeConfigurations."jsg@amd".activationPackage.type'`

The Nix eval completed successfully and returned `derivation`. It emitted the existing `programs.ssh.matchBlocks` deprecation trace from current config, unrelated to this change.