### PR TITLE
style(bin): align bak bash

### DIFF
--- a/bin/bak
+++ b/bin/bak
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 IFS=$'\n\t'
 
 # Check if the script received exactly one argument
-if [ "$#" -ne 1 ]; then
-    echo "Error: bak requires exactly one path"
-    exit 1
+if (($# != 1)); then
+	echo "Error: bak requires exactly one path"
+	exit 1
 fi
 
 # Check if the argument is a directory or a file
-if [ ! -d "$1" ] && [ ! -f "$1" ]; then
-    echo "Error: the specified path is neither a file nor a directory"
-    exit 1
+if [[ ! -d "$1" && ! -f "$1" ]]; then
+	echo "Error: the specified path is neither a file nor a directory"
+	exit 1
 fi
 
 # Define the backup path
@@ -19,8 +19,8 @@ backup_path="$1.bak"
 
 # Copy the file or directory to the backup path
 if cp -r "$1" "$backup_path"; then
-    echo "Backup of '$1' created at '$backup_path'"
+	echo "Backup of '$1' created at '$backup_path'"
 else
-    echo "Error: failed to create backup"
-    exit 1
+	echo "Error: failed to create backup"
+	exit 1
 fi


### PR DESCRIPTION
## Summary
- align `bin/bak` with the ysap Bash style guide
- remove `set -e` and switch simple tests to Bash conditionals

## Validation
- `shellcheck bin/bak`
- `bash -n bin/bak`
- `coderabbit review --agent --type committed --base origin/main --dir /tmp/hm-pr-split` (findings: 0)