### PR TITLE
style(bin): align ddroid bash

### DIFF
--- a/bin/ddroid
+++ b/bin/ddroid
@@ -2,145 +2,149 @@
 
 set -u
 
-if ! declare -F session_wrapper_find_file >/dev/null ||
-  ! declare -F session_wrapper_default_file >/dev/null ||
-  ! declare -F session_wrapper_load_id >/dev/null ||
-  ! declare -F session_wrapper_save_id >/dev/null; then
-  session_wrapper_script_path="${BASH_SOURCE[0]}"
-  while [[ -L "$session_wrapper_script_path" ]]; do
-    session_wrapper_script_dir=$(
-      CDPATH='' cd -P -- "$(dirname -- "$session_wrapper_script_path")" && pwd -P
-    )
-    session_wrapper_script_path=$(readlink -- "$session_wrapper_script_path")
-    if [[ "$session_wrapper_script_path" != /* ]]; then
-      session_wrapper_script_path="$session_wrapper_script_dir/$session_wrapper_script_path"
-    fi
-  done
-  session_wrapper_script_dir=$(
-    CDPATH='' cd -P -- "$(dirname -- "$session_wrapper_script_path")" && pwd -P
-  )
-  # shellcheck disable=SC1091
-  if ! . "$session_wrapper_script_dir/lib/session-wrapper-common.sh"; then
-    echo "Failed to source session wrapper helpers from '$session_wrapper_script_dir/lib/session-wrapper-common.sh'" >&2
-    exit 1
-  fi
-  if ! declare -F session_wrapper_find_file >/dev/null ||
-    ! declare -F session_wrapper_default_file >/dev/null ||
-    ! declare -F session_wrapper_load_id >/dev/null ||
-    ! declare -F session_wrapper_save_id >/dev/null; then
-    echo "Missing required session wrapper helper(s) after sourcing common library" >&2
-    exit 1
-  fi
-  unset session_wrapper_script_path
-  unset session_wrapper_script_dir
+if [[ $(type -t session_wrapper_find_file) != function ]] \
+	|| [[ $(type -t session_wrapper_default_file) != function ]] \
+	|| [[ $(type -t session_wrapper_load_id) != function ]] \
+	|| [[ $(type -t session_wrapper_save_id) != function ]]; then
+	session_wrapper_script_path="${BASH_SOURCE[0]}"
+	while [[ -L "$session_wrapper_script_path" ]]; do
+		session_wrapper_script_dir="${session_wrapper_script_path%/*}"
+		[[ "$session_wrapper_script_dir" == "$session_wrapper_script_path" ]] && session_wrapper_script_dir='.'
+		session_wrapper_script_dir=$(
+			CDPATH='' cd -P -- "$session_wrapper_script_dir" && pwd -P
+		) || exit
+		session_wrapper_script_path=$(readlink -- "$session_wrapper_script_path")
+		if [[ "$session_wrapper_script_path" != /* ]]; then
+			session_wrapper_script_path="$session_wrapper_script_dir/$session_wrapper_script_path"
+		fi
+	done
+	session_wrapper_script_dir="${session_wrapper_script_path%/*}"
+	[[ "$session_wrapper_script_dir" == "$session_wrapper_script_path" ]] && session_wrapper_script_dir='.'
+	session_wrapper_script_dir=$(
+		CDPATH='' cd -P -- "$session_wrapper_script_dir" && pwd -P
+	) || exit
+	# shellcheck disable=SC1091
+	if ! . "$session_wrapper_script_dir/lib/session-wrapper-common.sh"; then
+		echo "Failed to source session wrapper helpers from '$session_wrapper_script_dir/lib/session-wrapper-common.sh'" >&2
+		exit 1
+	fi
+	if [[ $(type -t session_wrapper_find_file) != function ]] \
+		|| [[ $(type -t session_wrapper_default_file) != function ]] \
+		|| [[ $(type -t session_wrapper_load_id) != function ]] \
+		|| [[ $(type -t session_wrapper_save_id) != function ]]; then
+		echo "Missing required session wrapper helper(s) after sourcing common library" >&2
+		exit 1
+	fi
+	unset session_wrapper_script_path
+	unset session_wrapper_script_dir
 fi
 
-readonly SESSION_PATTERN='droid --resume [a-f0-9-]*'
-readonly SESSION_FILE_NAME='.droid'
+session_pattern='droid --resume [a-f0-9-]*'
+session_file_name='.droid'
 
 cleanup() {
-  local exit_code=$?
-  [[ -n "${stderr_file:-}" && -f "$stderr_file" ]] && rm -f "$stderr_file"
-  return "$exit_code"
+	local exit_code=$?
+	[[ -n "${stderr_file:-}" && -f "$stderr_file" ]] && rm -f "$stderr_file"
+	return "$exit_code"
 }
 trap cleanup EXIT
 
 display_usage() {
-  cat <<EOF
-Usage: $(basename "$0") [-n] [-f] [-r session_id] [--] [droid_args...]
+	cat <<EOF
+Usage: ${0##*/} [-n] [-f] [-r session_id] [--] [droid_args...]
 
-Resume the last saved droid session from $SESSION_FILE_NAME unless told to start fresh.
+Resume the last saved droid session from $session_file_name unless told to start fresh.
 
 Options:
   -n              Ignore any saved session and start a new one
-  -f              Save the next session to ./$SESSION_FILE_NAME and do not auto-resume
-  -r session_id   Resume the given session id and skip $SESSION_FILE_NAME auto-resume
+  -f              Save the next session to ./$session_file_name and do not auto-resume
+  -r session_id   Resume the given session id and skip $session_file_name auto-resume
   -h              Show this help and droid's help
 
 Original droid help:
 EOF
-  droid --help
+	droid --help
 }
 
 extract_session_id() {
-  local stderr_file="$1"
+	local stderr_file="$1"
 
-  if ! grep -q "$SESSION_PATTERN" "$stderr_file"; then
-    return 1
-  fi
+	if ! grep -q "$session_pattern" "$stderr_file"; then
+		return 1
+	fi
 
-  grep -o "$SESSION_PATTERN" "$stderr_file" | sed 's/droid --resume //'
+	grep -o "$session_pattern" "$stderr_file" | sed 's/droid --resume //'
 }
 
 main() {
-  local session_id
-  local force_new_session=false
-  local force_current_dir=false
-  local droid_args=()
+	local session_id
+	local force_new_session=false
+	local force_current_dir=false
+	local droid_args=()
 
-  local OPTIND=1
-  while getopts ":hnfr:" opt; do
-    case "${opt}" in
-      h)
-        display_usage
-        return 0
-        ;;
-      n)
-        force_new_session=true
-        ;;
-      f)
-        force_current_dir=true
-        force_new_session=true
-        ;;
-      r)
-        force_new_session=true
-        droid_args+=("-r" "${OPTARG}")
-        ;;
-      \?)
-        echo "Invalid option: -${OPTARG}" >&2
-        return 2
-        ;;
-      :)
-        echo "Option -${OPTARG} requires an argument" >&2
-        return 2
-        ;;
-    esac
-  done
+	local OPTIND=1
+	while getopts ":hnfr:" opt; do
+		case "${opt}" in
+			h)
+				display_usage
+				return 0
+				;;
+			n)
+				force_new_session=true
+				;;
+			f)
+				force_current_dir=true
+				force_new_session=true
+				;;
+			r)
+				force_new_session=true
+				droid_args+=("-r" "${OPTARG}")
+				;;
+			\?)
+				echo "Invalid option: -${OPTARG}" >&2
+				return 2
+				;;
+			:)
+				echo "Option -${OPTARG} requires an argument" >&2
+				return 2
+				;;
+		esac
+	done
 
-  shift $((OPTIND - 1))
-  droid_args+=("$@")
+	shift $((OPTIND - 1))
+	droid_args+=("$@")
 
-  stderr_file=$(mktemp)
+	stderr_file=$(mktemp)
 
-  # Where to persist a new session id (not where to resume from).
-  local session_file
-  if [[ "$force_current_dir" == true ]]; then
-    session_file="./$SESSION_FILE_NAME"
-  else
-    session_file=$(session_wrapper_default_file "$SESSION_FILE_NAME")
-  fi
+	# Where to persist a new session id (not where to resume from).
+	local session_file
+	if [[ "$force_current_dir" == true ]]; then
+		session_file="./$session_file_name"
+	else
+		session_file=$(session_wrapper_default_file "$session_file_name")
+	fi
 
-  if [[ "$force_new_session" == false ]] && session_id=$(session_wrapper_load_id "$SESSION_FILE_NAME"); then
-    echo "Resuming droid session: $session_id"
-    droid --resume "$session_id" "${droid_args[@]}" 2>"$stderr_file"
-  else
-    droid "${droid_args[@]}" 2>"$stderr_file"
-  fi
+	if [[ "$force_new_session" == false ]] && session_id=$(session_wrapper_load_id "$session_file_name"); then
+		echo "Resuming droid session: $session_id"
+		droid --resume "$session_id" "${droid_args[@]}" 2>"$stderr_file"
+	else
+		droid "${droid_args[@]}" 2>"$stderr_file"
+	fi
 
-  local droid_exit_code=$?
+	local droid_exit_code=$?
 
-  if new_session_id=$(extract_session_id "$stderr_file"); then
-    session_wrapper_save_id "$new_session_id" "$session_file"
-    local save_exit_code=$?
-    if [[ "$save_exit_code" -eq 0 ]]; then
-      echo "Session ID saved to $session_file: $new_session_id" >&2
-    else
-      echo "Failed to save session ID '$new_session_id' to '$session_file'" >&2
-      return "$save_exit_code"
-    fi
-  fi
+	if new_session_id=$(extract_session_id "$stderr_file"); then
+		session_wrapper_save_id "$new_session_id" "$session_file"
+		local save_exit_code=$?
+		if [[ "$save_exit_code" -eq 0 ]]; then
+			echo "Session ID saved to $session_file: $new_session_id" >&2
+		else
+			echo "Failed to save session ID '$new_session_id' to '$session_file'" >&2
+			return "$save_exit_code"
+		fi
+	fi
 
-  return $droid_exit_code
+	return $droid_exit_code
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- align `bin/ddroid` with the ysap Bash style guide
- remove `readonly`/`declare -F` usage, avoid `dirname`, and format the script consistently

## Validation
- `shellcheck bin/ddroid`
- `bash -n bin/ddroid`
- `coderabbit review --agent --type committed --base origin/main --dir /tmp/hm-pr-split` (findings: 0)