### PR TITLE
style(bin): align docker volume copy bash

### DIFF
--- a/bin/docker-volume-copy
+++ b/bin/docker-volume-copy
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -uo pipefail
 
 print_help() {
-  cat <<EOF
+	cat <<EOF
 Usage: $0 [-h] <source_volume> <destination_volume>
 
 Copy data from one Docker volume to another.
@@ -14,37 +14,37 @@ EOF
 }
 
 while getopts "h" opt; do
-  case ${opt} in
-    h )
-      print_help
-      exit 0
-      ;;
-    \? )
-      echo "Invalid option: -$OPTARG" >&2
-      print_help
-      exit 1
-      ;;
-  esac
+	case ${opt} in
+		h)
+			print_help
+			exit 0
+			;;
+		\?)
+			echo "Invalid option: -$OPTARG" >&2
+			print_help
+			exit 1
+			;;
+	esac
 done
 
-shift $((OPTIND -1))
+shift $((OPTIND - 1))
 
-if [ "$#" -ne 2 ]; then
-  echo "Error: Incorrect number of arguments."
-  print_help
-  exit 1
+if (($# != 2)); then
+	echo "Error: Incorrect number of arguments."
+	print_help
+	exit 1
 fi
 
-VOLUME_A="$1"
-VOLUME_B="$2"
+volume_a="$1"
+volume_b="$2"
 
 if docker run --rm \
-  -v "${VOLUME_A}:/from_volume" \
-  -v "${VOLUME_B}:/to_volume" \
-  alpine \
-  sh -c "cp -a /from_volume/. /to_volume/"; then
-  echo "Successfully copied data from volume '${VOLUME_A}' to volume '${VOLUME_B}'"
+	-v "${volume_a}:/from_volume" \
+	-v "${volume_b}:/to_volume" \
+	alpine \
+	sh -c "cp -a /from_volume/. /to_volume/"; then
+	echo "Successfully copied data from volume '${volume_a}' to volume '${volume_b}'"
 else
-  echo "An error occurred during the volume copy" >&2
-  exit 1
+	echo "An error occurred during the volume copy" >&2
+	exit 1
 fi


### PR DESCRIPTION
## Summary
- align `bin/docker-volume-copy` with the ysap Bash style guide
- remove `set -e`, use Bash arithmetic for argument checks, and format consistently

## Validation
- `shellcheck bin/docker-volume-copy`
- `bash -n bin/docker-volume-copy`
- `coderabbit review --agent --type committed --base origin/main --dir /tmp/hm-pr-split` (findings: 0)