### PR TITLE
style(bin): align emacs clean bash

### DIFF
--- a/bin/emacs-clean
+++ b/bin/emacs-clean
@@ -1,59 +1,59 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 IFS=$'\n\t'
 
 # Function to delete files using fd
 delete_with_fd() {
-    echo "Using fd to delete files..."
-    fd -HI '~$' -x rm -v '{}'
-    fd -HI '^#.*#$' -x rm -v '{}'
+	echo "Using fd to delete files..."
+	fd -HI '~$' -x rm -v '{}'
+	fd -HI '^#.*#$' -x rm -v '{}'
 }
 
 # Function to find files using fd
 list_with_fd() {
-    echo "Using fd to list files to be deleted..."
-    fd -HI '~$'
-    fd -HI '^#.*#$'
+	echo "Using fd to list files to be deleted..."
+	fd -HI '~$'
+	fd -HI '^#.*#$'
 }
 
 # Function to delete files using find
 delete_with_find() {
-    echo "Using find to delete files..."
-    find . -name '*~' -exec rm -v "{}" \;
-    find . -name '*#*' -exec rm -v "{}" \;
+	echo "Using find to delete files..."
+	find . -name '*~' -exec rm -v "{}" \;
+	find . -name '*#*' -exec rm -v "{}" \;
 }
 
 # Function to find files using find
 list_with_find() {
-    echo "Using find to list files to be deleted..."
-    find . -name '*~'
-    find . -name '*#*'
+	echo "Using find to list files to be deleted..."
+	find . -name '*~'
+	find . -name '*#*'
 }
 
 # Default action is to delete files
-ACTION="delete"
+action="delete"
 
 # Parse arguments
-if [ "$#" -gt 0 ]; then
-    if [ "$1" = "--dry-run" ]; then
-	ACTION="list"
-    else
-	echo "Usage: $0 [--dry-run]"
-	exit 1
-    fi
+if (($# > 0)); then
+	if [[ "$1" == "--dry-run" ]]; then
+		action="list"
+	else
+		echo "Usage: $0 [--dry-run]"
+		exit 1
+	fi
 fi
 
 # Check if fd is available and perform the appropriate action
-if command -v fd &> /dev/null; then
-    if [ "$ACTION" = "delete" ]; then
-	delete_with_fd
-    else
-	list_with_fd
-    fi
+if command -v fd &>/dev/null; then
+	if [[ "$action" == "delete" ]]; then
+		delete_with_fd
+	else
+		list_with_fd
+	fi
 else
-    if [ "$ACTION" = "delete" ]; then
-	delete_with_find
-    else
-	list_with_find
-    fi
+	if [[ "$action" == "delete" ]]; then
+		delete_with_find
+	else
+		list_with_find
+	fi
 fi


### PR DESCRIPTION
## Summary
- align `bin/emacs-clean` with the ysap Bash style guide
- remove `set -e`, use Bash conditionals, and format consistently

## Validation
- `shellcheck bin/emacs-clean`
- `bash -n bin/emacs-clean`
- `coderabbit review --agent --type committed --base origin/main --dir /tmp/hm-pr-split` (findings: 0)