### PR TITLE
style(bin): align hm switch bash

### DIFF
--- a/bin/hm-switch
+++ b/bin/hm-switch
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
 flakePath="${XDG_CONFIG_HOME:-$HOME/.config}/home-manager"
 


### PR DESCRIPTION
## Summary
- align `bin/hm-switch` with the ysap Bash style guide
- remove `set -e` while preserving the switch pipeline

## Validation
- `shellcheck bin/hm-switch`
- `bash -n bin/hm-switch`
- `coderabbit review --agent --type committed --base origin/main --dir /tmp/hm-pr-split` (findings: 0)