### PR TITLE
style(bin): align hm switch update bash

### DIFF
--- a/bin/hm-switch-update
+++ b/bin/hm-switch-update
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
 flakePath="${XDG_CONFIG_HOME:-$HOME/.config}/home-manager"
 
 if command -v gh >/dev/null 2>&1 && [[ "${NIX_CONFIG:-}" != *"access-tokens"* ]]; then
-  githubToken="$(gh auth token -h github.com 2>/dev/null || true)"
-  if [[ -n "$githubToken" ]]; then
-    export NIX_CONFIG="access-tokens = github.com=$githubToken"
-  fi
+	githubToken="$(gh auth token -h github.com 2>/dev/null || true)"
+	if [[ -n "$githubToken" ]]; then
+		export NIX_CONFIG="access-tokens = github.com=$githubToken"
+	fi
 fi
 
 nix flake update --flake "$flakePath" && home-manager switch --flake "$flakePath" "$@" 2>&1 | nom


### PR DESCRIPTION
## Summary
- align `bin/hm-switch-update` with the ysap Bash style guide
- remove `set -e` and apply tab-indented Bash formatting

## Validation
- `shellcheck bin/hm-switch-update`
- `bash -n bin/hm-switch-update`
- `coderabbit review --agent --type committed --base origin/main --dir /tmp/hm-pr-split` (findings: 0)