### PR TITLE
style(bin): align nix find bash

### DIFF
--- a/bin/nix-find
+++ b/bin/nix-find
@@ -5,35 +5,35 @@ interactive=true
 
 # Parse options
 while getopts ":p" opt; do
-  case ${opt} in
-    p )
-      interactive=false
-      ;;
-    \? )
-      echo "Invalid option: $OPTARG" 1>&2
-      exit 1
-      ;;
-  esac
+	case ${opt} in
+		p)
+			interactive=false
+			;;
+		\?)
+			echo "Invalid option: $OPTARG" 1>&2
+			exit 1
+			;;
+	esac
 done
-shift $((OPTIND -1))
+shift $((OPTIND - 1))
 
 queries=("$@")
 
-if [ "$interactive" = false ]; then
-  # Non-interactive mode: filter and print
-  nix-search-tv print "${queries[@]}" | fzf --filter="${queries[*]}"
-  exit 0
+if [[ "$interactive" == false ]]; then
+	# Non-interactive mode: filter and print
+	nix-search-tv print "${queries[@]}" | fzf --filter="${queries[*]}"
+	exit 0
 fi
 
 # Helper: extract package names from selection lines
 nix_find_extract_pkgs() {
-  local pkgs=()
-  local attr
-  for sel in "$@"; do
-    attr=$(echo "$sel" | awk -F'/ +' '{print $2}' | tr -d ' ')
-    [ -n "$attr" ] && pkgs+=("$attr")
-  done
-  echo "${pkgs[*]}"
+	local pkgs=()
+	local attr
+	for sel in "$@"; do
+		attr=$(echo "$sel" | awk -F'/ +' '{print $2}' | tr -d ' ')
+		[[ -n "$attr" ]] && pkgs+=("$attr")
+	done
+	echo "${pkgs[*]}"
 }
 export -f nix_find_extract_pkgs
 
@@ -43,34 +43,34 @@ info_cmd='echo "nix-shell -p $(nix_find_extract_pkgs {+})"'
 
 # Interactive mode
 mapfile -t selections < <(
-  nix-search-tv print "${queries[@]}" \
-    | fzf \
-        --ansi \
-        --multi \
-        --query="${queries[*]}" \
-        --prompt="❄ Query> " \
-        --scheme=history \
-        --preview-window=down:60%:wrap \
-        --preview 'nix-search-tv preview {}' \
-        --bind "enter:accept" \
-        --bind "alt-c:execute-silent(echo {} | awk -F'/ +' '{print \$2}' | tr -d ' ' | wl-copy 2>/dev/null || xclip -selection clipboard)" \
-        --bind "alt-l:toggle-preview" \
-        --header $'TAB mark • ENTER select • Alt-C copy • Alt-L toggle preview' \
-        --info-command "$info_cmd"
+	nix-search-tv print "${queries[@]}" \
+		| fzf \
+			--ansi \
+			--multi \
+			--query="${queries[*]}" \
+			--prompt="❄ Query> " \
+			--scheme=history \
+			--preview-window=down:60%:wrap \
+			--preview 'nix-search-tv preview {}' \
+			--bind "enter:accept" \
+			--bind "alt-c:execute-silent(echo {} | awk -F'/ +' '{print \$2}' | tr -d ' ' | wl-copy 2>/dev/null || xclip -selection clipboard)" \
+			--bind "alt-l:toggle-preview" \
+			--header $'TAB mark • ENTER select • Alt-C copy • Alt-L toggle preview' \
+			--info-command "$info_cmd"
 )
 status=$?
 
-if [ $status -eq 130 ]; then
-  echo "Selection cancelled." >&2
-  exit 130
-elif [ ${#selections[@]} -eq 0 ]; then
-  echo "No package selected." >&2
-  exit 0
+if ((status == 130)); then
+	echo "Selection cancelled." >&2
+	exit 130
+elif ((${#selections[@]} == 0)); then
+	echo "No package selected." >&2
+	exit 0
 fi
 
 # Extract package names using the same function
 pkgs_str=$(nix_find_extract_pkgs "${selections[@]}")
-IFS=' ' read -ra pkgs <<< "$pkgs_str"
+IFS=' ' read -ra pkgs <<<"$pkgs_str"
 
 printf 'nix-shell -p'
 printf ' %q' "${pkgs[@]}"


### PR DESCRIPTION
## Summary
- align `bin/nix-find` with the ysap Bash style guide
- switch tests to Bash conditionals and format consistently

## Validation
- `shellcheck bin/nix-find`
- `bash -n bin/nix-find`
- `coderabbit review --agent --type committed --base origin/main --dir /tmp/hm-pr-split` (findings: 0)