### PR TITLE
style(bin): align ooc bash

### DIFF
--- a/bin/ooc
+++ b/bin/ooc
@@ -2,30 +2,37 @@
 
 set -u
 
-if ! declare -F session_wrapper_find_file >/dev/null; then
-  session_wrapper_script_dir=$(
-    CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd
-  )
-  # shellcheck disable=SC1091
-  . "$session_wrapper_script_dir/lib/session-wrapper-common.sh"
-  unset session_wrapper_script_dir
+if [[ $(type -t session_wrapper_find_file) != function ]]; then
+	session_wrapper_script_path="${BASH_SOURCE[0]}"
+	session_wrapper_script_dir="${session_wrapper_script_path%/*}"
+	[[ "$session_wrapper_script_dir" == "$session_wrapper_script_path" ]] && session_wrapper_script_dir='.'
+	session_wrapper_script_dir=$(
+		CDPATH='' cd -- "$session_wrapper_script_dir" && pwd
+	) || exit
+	# shellcheck disable=SC1091
+	if ! . "$session_wrapper_script_dir/lib/session-wrapper-common.sh"; then
+		echo "Failed to source session wrapper helpers from '$session_wrapper_script_dir/lib/session-wrapper-common.sh'" >&2
+		exit 1
+	fi
+	unset session_wrapper_script_path
+	unset session_wrapper_script_dir
 fi
 
-readonly SESSION_PATTERN='opencode -s ses_[A-Za-z0-9_-]*'
-readonly EXIT_MARKER='__OOC_EXIT_CODE__:'
-readonly SESSION_FILE_NAME='.ooc'
+session_pattern='opencode -s ses_[A-Za-z0-9_-]*'
+exit_marker='__OOC_EXIT_CODE__:'
+session_file_name='.ooc'
 
 cleanup() {
-  local exit_code=$?
-  [[ -n "${transcript_file:-}" && -f "$transcript_file" ]] && rm -f "$transcript_file"
-  [[ -n "${runner_file:-}" && -f "$runner_file" ]] && rm -f "$runner_file"
-  return "$exit_code"
+	local exit_code=$?
+	[[ -n "${transcript_file:-}" && -f "$transcript_file" ]] && rm -f "$transcript_file"
+	[[ -n "${runner_file:-}" && -f "$runner_file" ]] && rm -f "$runner_file"
+	return "$exit_code"
 }
 trap cleanup EXIT
 
 display_usage() {
-  cat <<EOF
-Usage: $(basename "$0") [-n] [-f] [-s session_id] [--] [opencode_args...]
+	cat <<EOF
+Usage: ${0##*/} [-n] [-f] [-s session_id] [--] [opencode_args...]
 
 Resume the last saved opencode session from .ooc unless told to start fresh.
 
@@ -37,83 +44,83 @@ Options:
 
 Original opencode help:
 EOF
-  opencode --help
+	opencode --help
 }
 
 extract_session_id() {
-  local transcript_file="$1"
-  local session_id
-  session_id=$(grep -a -o "$SESSION_PATTERN" "$transcript_file" | sed 's/opencode -s //' | tail -n1)
+	local transcript_file="$1"
+	local session_id
+	session_id=$(grep -a -o "$session_pattern" "$transcript_file" | sed 's/opencode -s //' | tail -n1)
 
-  if [[ -z "$session_id" ]]; then
-    return 1
-  fi
+	if [[ -z "$session_id" ]]; then
+		return 1
+	fi
 
-  echo "$session_id"
+	echo "$session_id"
 }
 
 main() {
-  local session_id
-  local new_session_id
-  local opencode_exit_code
-  local opencode_exec_args=()
-  local script_cmd
-  local exit_line
-  local force_new_session=false
-  local force_current_dir=false
-  local opencode_args=()
+	local session_id
+	local new_session_id
+	local opencode_exit_code
+	local opencode_exec_args=()
+	local script_cmd
+	local exit_line
+	local force_new_session=false
+	local force_current_dir=false
+	local opencode_args=()
 
-  local OPTIND=1
-  while getopts ":hnfs:" opt; do
-    case "${opt}" in
-      h)
-        display_usage
-        return 0
-        ;;
-      n)
-        force_new_session=true
-        ;;
-      f)
-        force_current_dir=true
-        force_new_session=true
-        ;;
-      s)
-        force_new_session=true
-        opencode_args+=("-s" "${OPTARG}")
-        ;;
-      \?)
-        echo "Invalid option: -${OPTARG}" >&2
-        return 2
-        ;;
-      :)
-        echo "Option -${OPTARG} requires an argument" >&2
-        return 2
-        ;;
-    esac
-  done
+	local OPTIND=1
+	while getopts ":hnfs:" opt; do
+		case "${opt}" in
+			h)
+				display_usage
+				return 0
+				;;
+			n)
+				force_new_session=true
+				;;
+			f)
+				force_current_dir=true
+				force_new_session=true
+				;;
+			s)
+				force_new_session=true
+				opencode_args+=("-s" "${OPTARG}")
+				;;
+			\?)
+				echo "Invalid option: -${OPTARG}" >&2
+				return 2
+				;;
+			:)
+				echo "Option -${OPTARG} requires an argument" >&2
+				return 2
+				;;
+		esac
+	done
 
-  shift $((OPTIND - 1))
-  opencode_args+=("$@")
+	shift $((OPTIND - 1))
+	opencode_args+=("$@")
 
-  # Where to persist a new session id (not where to resume from).
-  local session_file
-  if [[ "$force_current_dir" == true ]]; then
-    session_file="./$SESSION_FILE_NAME"
-  else
-    session_file=$(session_wrapper_default_file "$SESSION_FILE_NAME")
-  fi
+	# Where to persist a new session id (not where to resume from).
+	local session_file
+	if [[ "$force_current_dir" == true ]]; then
+		session_file="./$session_file_name"
+	else
+		session_file=$(session_wrapper_default_file "$session_file_name")
+	fi
 
-  if [[ "$force_new_session" == false ]] && session_id=$(session_wrapper_load_id "$SESSION_FILE_NAME"); then
-    echo "Resuming opencode session: $session_id"
-    opencode_exec_args=("-s" "$session_id" "${opencode_args[@]}")
-  else
-    opencode_exec_args=("${opencode_args[@]}")
-  fi
+	if [[ "$force_new_session" == false ]] && session_id=$(session_wrapper_load_id "$session_file_name"); then
+		echo "Resuming opencode session: $session_id"
+		opencode_exec_args=("-s" "$session_id" "${opencode_args[@]}")
+	else
+		opencode_exec_args=("${opencode_args[@]}")
+	fi
 
-  transcript_file=$(mktemp)
-  runner_file=$(mktemp)
+	transcript_file=$(mktemp)
+	runner_file=$(mktemp)
 
-  cat >"$runner_file" <<EOF
+	cat >"$runner_file" <<EOF
 #!/usr/bin/env bash
 interrupted=0
 trap 'interrupted=1' INT
@@ -125,38 +132,38 @@ if [[ \$interrupted -eq 1 && \$code -eq 0 ]]; then
   code=130
 fi
 
-printf "${EXIT_MARKER}%s\n" "\$code"
+printf "${exit_marker}%s\n" "\$code"
 exit 0
 EOF
-  chmod +x "$runner_file"
+	chmod +x "$runner_file"
 
-  script_cmd="$runner_file"
-  local arg
-  for arg in "${opencode_exec_args[@]}"; do
-    printf -v script_cmd '%s %q' "$script_cmd" "$arg"
-  done
+	script_cmd="$runner_file"
+	local arg
+	for arg in "${opencode_exec_args[@]}"; do
+		printf -v script_cmd '%s %q' "$script_cmd" "$arg"
+	done
 
-  script -q -c "$script_cmd" "$transcript_file"
+	script -q -c "$script_cmd" "$transcript_file"
 
-  exit_line=$(grep -a -o "${EXIT_MARKER}[0-9][0-9]*" "$transcript_file" | tail -n1)
-  if [[ -n "$exit_line" ]]; then
-    opencode_exit_code=${exit_line#"${EXIT_MARKER}"}
-  else
-    opencode_exit_code=1
-  fi
+	exit_line=$(grep -a -o "${exit_marker}[0-9][0-9]*" "$transcript_file" | tail -n1)
+	if [[ -n "$exit_line" ]]; then
+		opencode_exit_code=${exit_line#"${exit_marker}"}
+	else
+		opencode_exit_code=1
+	fi
 
-  if new_session_id=$(extract_session_id "$transcript_file"); then
-    session_wrapper_save_id "$new_session_id" "$session_file"
-    local save_exit_code=$?
-    if [[ "$save_exit_code" -eq 0 ]]; then
-      echo "Session ID saved to $session_file: $new_session_id" >&2
-    else
-      echo "Failed to save session ID '$new_session_id' to '$session_file'" >&2
-      return "$save_exit_code"
-    fi
-  fi
+	if new_session_id=$(extract_session_id "$transcript_file"); then
+		session_wrapper_save_id "$new_session_id" "$session_file"
+		local save_exit_code=$?
+		if [[ "$save_exit_code" -eq 0 ]]; then
+			echo "Session ID saved to $session_file: $new_session_id" >&2
+		else
+			echo "Failed to save session ID '$new_session_id' to '$session_file'" >&2
+			return "$save_exit_code"
+		fi
+	fi
 
-  return "$opencode_exit_code"
+	return "$opencode_exit_code"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- align `bin/ooc` with the ysap Bash style guide
- remove `readonly`/`declare -F` usage, avoid simple `dirname`, and format consistently

## Validation
- `shellcheck bin/ooc`
- `bash -n bin/ooc`
- `coderabbit review --agent --type committed --base origin/main --dir /tmp/hm-pr-split` (findings: 0)