### PR TITLE
style(bin): align spectacle ocr bash

### DIFF
--- a/bin/spectacle-ocr
+++ b/bin/spectacle-ocr
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 IFS=$'\n\t'
 
 temp_file=$(mktemp /tmp/spectacle.XXXXXX.png)
 spectacle -rnbo "$temp_file"
 
-if [ -f "$temp_file" ]; then
-    for i in {0..13}; do
-        echo -e "\n RUNNING PSM $i \n"
-        tesseract "$temp_file" stdout --psm "$i"
-        read -rp "Press to continue... "
-    done
-    rm "$temp_file"
+if [[ -f "$temp_file" ]]; then
+	for i in {0..13}; do
+		echo -e "\n RUNNING PSM $i \n"
+		tesseract "$temp_file" stdout --psm "$i"
+		read -rp "Press to continue... "
+	done
+	rm "$temp_file"
 else
-    echo "Error: Screenshot failed."
-    exit 1
+	echo "Error: Screenshot failed."
+	exit 1
 fi


### PR DESCRIPTION
## Summary
- align `bin/spectacle-ocr` with the ysap Bash style guide
- remove `set -e`, use Bash conditionals, and format consistently

## Validation
- `shellcheck bin/spectacle-ocr`
- `bash -n bin/spectacle-ocr`
- `coderabbit review --agent --type committed --base origin/main --dir /tmp/hm-pr-split` (findings: 0)