### PR TITLE
style(bin): align update all bash

### DIFF
--- a/bin/update-all
+++ b/bin/update-all
@@ -3,10 +3,10 @@
 flakePath="${XDG_CONFIG_HOME:-$HOME/.config}/home-manager"
 
 if command -v gh >/dev/null 2>&1 && [[ "${NIX_CONFIG:-}" != *"access-tokens"* ]]; then
-  githubToken="$(gh auth token -h github.com 2>/dev/null || true)"
-  if [[ -n "$githubToken" ]]; then
-    export NIX_CONFIG="access-tokens = github.com=$githubToken"
-  fi
+	githubToken="$(gh auth token -h github.com 2>/dev/null || true)"
+	if [[ -n "$githubToken" ]]; then
+		export NIX_CONFIG="access-tokens = github.com=$githubToken"
+	fi
 fi
 
 # Parallel updates


### PR DESCRIPTION
## Summary
- align `bin/update-all` with the ysap Bash style guide
- apply tab-indented Bash formatting to the GitHub token guard

## Validation
- `shellcheck bin/update-all`
- `bash -n bin/update-all`
- `coderabbit review --agent --type committed --base origin/main --dir /tmp/hm-pr-split` (findings: 0)