### PR TITLE
[codex] add git worktree cd picker

### DIFF
--- a/bin/git-worktree-cd
+++ b/bin/git-worktree-cd
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+
+print_help() {
+  cat <<'EOF'
+git-worktree-cd - pick a git worktree directory
+
+Usage:
+  git-worktree-cd              Pick a worktree path and print it
+  git-worktree-cd --print      Pick a worktree path and print it
+  git-worktree-cd --init bash  Print shell function for cd integration
+
+Examples:
+  cd "$(git-worktree-cd)"
+  source <(git-worktree-cd --init bash)
+
+Notes:
+  fzf 0.33.0+ enables history ranking.
+EOF
+}
+
+print_init() {
+  local git_worktree_cd_bin=""
+  local resolved_bin=""
+
+  if resolved_bin="$(command -v "$0" 2>/dev/null)"; then
+    git_worktree_cd_bin="$resolved_bin"
+  elif [[ "$0" == /* ]]; then
+    git_worktree_cd_bin="$0"
+  else
+    git_worktree_cd_bin="$PWD/${0#./}"
+  fi
+
+  if command -v realpath >/dev/null 2>&1; then
+    git_worktree_cd_bin="$(realpath "$git_worktree_cd_bin")"
+  fi
+
+  case "$1" in
+    bash | zsh)
+      cat <<EOF
+git-worktree-cd() {
+  local target
+  target="\$("$git_worktree_cd_bin" --print "\$@")" || return \$?
+  [[ -n "\$target" ]] || return 1
+  cd "\$target" || return
+}
+EOF
+      ;;
+    *)
+      printf 'Unsupported shell: %s\n' "$1" >&2
+      return 1
+      ;;
+  esac
+}
+
+repo_root() {
+  git rev-parse --show-toplevel 2>/dev/null
+}
+
+list_worktrees() {
+  local root="$1"
+  local path=""
+  local branch=""
+  local bare=0
+  local detached=0
+
+  emit_worktree() {
+    [[ -n "$path" ]] || return 0
+
+    local label="$branch"
+    if [[ -z "$label" ]] && (( detached == 1 )); then
+      label="detached"
+    elif [[ -z "$label" ]] && (( bare == 1 )); then
+      label="bare"
+    elif [[ -z "$label" ]]; then
+      label="-"
+    fi
+
+    printf '%s\t%s\n' "$path" "$label"
+  }
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ -z "$line" ]]; then
+      emit_worktree
+      path=""
+      branch=""
+      bare=0
+      detached=0
+      continue
+    fi
+
+    case "$line" in
+      worktree\ *)
+        path="${line#worktree }"
+        ;;
+      branch\ refs/heads/*)
+        branch="${line#branch refs/heads/}"
+        ;;
+      branch\ *)
+        branch="${line#branch }"
+        ;;
+      bare)
+        bare=1
+        ;;
+      detached)
+        detached=1
+        ;;
+    esac
+  done < <(git -C "$root" worktree list --porcelain)
+
+  emit_worktree
+}
+
+worktree_preview_command() {
+  cat <<'EOF'
+bash -c '
+path="$1"
+[[ -d "$path" ]] || exit 1
+
+git -C "$path" status --short --branch
+printf "\n"
+
+if command -v eza >/dev/null 2>&1; then
+  eza --tree --color=always "$path" | head -200
+elif command -v find >/dev/null 2>&1; then
+  find "$path" -maxdepth 3 -print 2>/dev/null | head -200
+else
+  printf "Install eza or find for worktree previews.\n" >&2
+fi
+' -- {2}
+EOF
+}
+
+format_worktrees() {
+  local -a rows=()
+  local row=""
+  local path=""
+  local branch=""
+  local path_width=0
+
+  mapfile -t rows
+
+  for row in "${rows[@]}"; do
+    IFS=$'\t' read -r path branch <<< "$row"
+    (( ${#path} > path_width )) && path_width="${#path}"
+  done
+
+  for row in "${rows[@]}"; do
+    IFS=$'\t' read -r path branch <<< "$row"
+    printf '%-*s  %s\t%s\n' "$path_width" "$path" "$branch" "$path"
+  done
+}
+
+fzf_supports_history_scheme() {
+  fzf --scheme=history --version >/dev/null 2>&1
+}
+
+choose_worktree() {
+  local root
+  root="$(repo_root)" || {
+    printf 'Not inside a git repository.\n' >&2
+    return 1
+  }
+
+  if ! command -v fzf >/dev/null 2>&1; then
+    printf 'Missing required command: fzf\n' >&2
+    return 1
+  fi
+
+  local preview_command
+  preview_command="$(worktree_preview_command)"
+
+  local -a fzf_args=(
+    --delimiter=$'\t'
+    --with-nth=1
+    --ansi
+    --prompt='Git worktree> '
+    --preview-window='right:60%:wrap'
+    --preview "$preview_command"
+    --bind 'enter:accept'
+    --bind 'alt-l:toggle-preview'
+    --bind 'ctrl-l:toggle-preview'
+    --header 'ENTER cd | Alt-L/Ctrl-L preview'
+  )
+
+  if fzf_supports_history_scheme; then
+    fzf_args+=(--scheme=history)
+  fi
+
+  local selected
+  selected="$(
+    list_worktrees "$root" \
+      | format_worktrees \
+      | fzf "${fzf_args[@]}"
+  )"
+
+  local status=$?
+  (( status == 130 )) && return 130
+  [[ -n "$selected" ]] || return 0
+
+  printf '%s\n' "${selected#*$'\t'}"
+}
+
+main() {
+  while (( $# > 0 )); do
+    case "$1" in
+      -h | --help)
+        print_help
+        return 0
+        ;;
+      -p | --print)
+        ;;
+      --init)
+        shift
+        if (( $# == 0 )); then
+          printf 'Missing shell for --init.\n' >&2
+          return 1
+        fi
+        print_init "$1"
+        return 0
+        ;;
+      --)
+        shift
+        break
+        ;;
+      -*)
+        printf 'Invalid option: %s\n' "$1" >&2
+        return 1
+        ;;
+      *)
+        printf 'Too many arguments.\n' >&2
+        return 1
+        ;;
+    esac
+    shift
+  done
+
+  choose_worktree
+}
+
+main "$@"

--- a/home/modules/package-sets.nix
+++ b/home/modules/package-sets.nix
@@ -222,6 +222,17 @@
       text = builtins.readFile ../../bin/rg-fuzzy;
     })
     (pkgs.writeShellApplication {
+      name = "git-worktree-cd";
+      runtimeInputs = [
+        pkgs.coreutils
+        pkgs.eza
+        pkgs.findutils
+        pkgs.fzf
+        pkgs.git
+      ];
+      text = builtins.readFile ../../bin/git-worktree-cd;
+    })
+    (pkgs.writeShellApplication {
       name = "update-all";
       runtimeInputs = [
         pkgs.gh

--- a/home/modules/programs.nix
+++ b/home/modules/programs.nix
@@ -180,6 +180,7 @@ in
 
             eval "$(batman --export-env)"
             eval "$(command up --init bash)"
+            source <(command git-worktree-cd --init bash)
           '';
         };
 
@@ -264,6 +265,7 @@ in
                 plog = "log --all --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --branches";
                 ignore-change = "update-index --assume-unchanged";
                 unstage = "restore --staged";
+                wt = "!git-worktree-cd";
               };
 
               credential = {


### PR DESCRIPTION
## Summary

Adds a `git-worktree-cd` fzf picker for jumping between Git worktrees, wires it into the Home Manager script package set, and exposes it as `git wt`.

The picker reads `git worktree list --porcelain`, displays aligned `<path> <branch>` rows, shows a right-side preview, and emits a shell function for actual `cd` integration.

```mermaid
sequenceDiagram
    participant User
    participant Git as git wt
    participant Picker as git-worktree-cd
    participant Fzf as fzf
    participant Shell

    User->>Git: git wt
    Git->>Picker: run picker alias
    Picker->>Fzf: list aligned worktrees
    Fzf-->>Picker: selected worktree path
    Picker-->>User: print path
    User->>Shell: git-worktree-cd shell function
    Shell->>Picker: resolve selected worktree
    Picker-->>Shell: target path
    Shell->>Shell: cd target path
```

## Validation

- `bash -n bin/git-worktree-cd`
- `shellcheck bin/git-worktree-cd`
- `FZF_DEFAULT_OPTS=--filter=nix-config git -c alias.wt='!bin/git-worktree-cd' wt --print`
- `bash -lc 'source <(bin/git-worktree-cd --init bash); type git-worktree-cd'`
- `nixfmt --check home/modules/package-sets.nix home/modules/programs.nix`
- `deadnix home/modules/package-sets.nix home/modules/programs.nix`
- `nix eval .#homeConfigurations --apply builtins.attrNames`