### PR TITLE
fix(git): make worktree alias change directory

### DIFF
--- a/bin/git-worktree-cd
+++ b/bin/git-worktree-cd
@@ -12,8 +12,10 @@ Usage:
 Examples:
   cd "$(git-worktree-cd)"
   source <(git-worktree-cd --init bash)
+  git wt
 
 Notes:
+  git wt changes directory after shell integration is sourced.
   fzf 0.33.0+ enables history ranking.
 EOF
 }
@@ -42,6 +44,16 @@ git-worktree-cd() {
   target="\$("$git_worktree_cd_bin" --print "\$@")" || return \$?
   [[ -n "\$target" ]] || return 1
   cd "\$target" || return
+}
+
+git() {
+  if [[ \$# -gt 0 && \$1 == wt ]]; then
+    shift
+    git-worktree-cd "\$@"
+    return \$?
+  fi
+
+  command git "\$@"
 }
 EOF
       ;;


### PR DESCRIPTION
## Summary
- make the shell integration intercept interactive `git wt` and run `cd` in the current shell
- keep normal `git` commands delegated to the real Git binary
- document that `git wt` requires sourced shell integration to change directory

## Verification
- `nix develop -c coderabbit review --agent --type uncommitted --dir bin` -> findings: 0
- `bash -n bin/git-worktree-cd`
- `shellcheck bin/git-worktree-cd`
- temp-repo smoke test: sourced init + `git wt` changed into the selected worktree
- pre-commit/pre-push hooks passed