### PR TITLE
Add Open Design Home Manager integration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,6 +74,29 @@
         "type": "github"
       }
     },
+    "dream2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "open-design",
+          "nixpkgs"
+        ],
+        "purescript-overlay": "purescript-overlay",
+        "pyproject-nix": "pyproject-nix_4"
+      },
+      "locked": {
+        "lastModified": 1765953015,
+        "narHash": "sha256-5FBZbbWR1Csp3Y2icfRkxMJw/a/5FGg8hCXej2//bbI=",
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "rev": "69eb01fa0995e1e90add49d8ca5bcba213b0416f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -91,6 +114,22 @@
       }
     },
     "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
       "flake": false,
       "locked": {
         "lastModified": 1767039857,
@@ -190,7 +229,7 @@
     },
     "git-hooks_2": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_3",
         "gitignore": "gitignore_2",
         "nixpkgs": [
           "waytorandr",
@@ -430,6 +469,58 @@
         "type": "github"
       }
     },
+    "open-design": {
+      "inputs": {
+        "dream2nix": "dream2nix",
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "home-manager": [
+          "home-manager"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781669576,
+        "narHash": "sha256-rSJVKNK0d2n5bS0ZvnF9i2LocEue2VmDYBUtEzXbf+I=",
+        "owner": "nexu-io",
+        "repo": "open-design",
+        "rev": "67ade60bced0f6f7888bf9dc487571f954e98e0d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nexu-io",
+        "ref": "open-design-v0.11.0",
+        "repo": "open-design",
+        "type": "github"
+      }
+    },
+    "purescript-overlay": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "nixpkgs": [
+          "open-design",
+          "dream2nix",
+          "nixpkgs"
+        ],
+        "slimlock": "slimlock"
+      },
+      "locked": {
+        "lastModified": 1728546539,
+        "narHash": "sha256-Sws7w0tlnjD+Bjck1nv29NjC5DbL6nH5auL9Ex9Iz2A=",
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "rev": "4ad4c15d07bd899d7346b331f377606631eb0ee4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "type": "github"
+      }
+    },
     "pyproject-build-systems": {
       "inputs": {
         "nixpkgs": [
@@ -518,6 +609,28 @@
         "type": "github"
       }
     },
+    "pyproject-nix_4": {
+      "inputs": {
+        "nixpkgs": [
+          "open-design",
+          "dream2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1763017646,
+        "narHash": "sha256-Z+R2lveIp6Skn1VPH3taQIuMhABg1IizJd8oVdmdHsQ=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "47bd6f296502842643078d66128f7b5e5370790c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "agent-browser-src": "agent-browser-src",
@@ -531,7 +644,7 @@
         "nixpkgs": "nixpkgs",
         "numtide-llm-agents": "numtide-llm-agents",
         "oh-my-opencode-slim-src": "oh-my-opencode-slim-src",
-        "t3code-flake": "t3code-flake",
+        "open-design": "open-design",
         "waytorandr": "waytorandr",
         "zen-browser": "zen-browser"
       }
@@ -554,6 +667,29 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "slimlock": {
+      "inputs": {
+        "nixpkgs": [
+          "open-design",
+          "dream2nix",
+          "purescript-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688756706,
+        "narHash": "sha256-xzkkMv3neJJJ89zo3o2ojp7nFeaZc2G0fYwNXNJRFlo=",
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "rev": "cf72723f59e2340d24881fd7bf61cb113b4c407c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
         "type": "github"
       }
     },
@@ -599,26 +735,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "t3code-flake": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1779170372,
-        "narHash": "sha256-elTjJXlrXusH2r9U8yG6+xSnSpDINzXsnn6848dOhpY=",
-        "owner": "jakob1379",
-        "repo": "t3code-flake",
-        "rev": "dedd8afb81cf889a0a1a4eccaa275b502b21b800",
-        "type": "github"
-      },
-      "original": {
-        "owner": "jakob1379",
-        "repo": "t3code-flake",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,12 @@
       url = "github:jakob1379/waytorandr";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    open-design = {
+      url = "github:nexu-io/open-design/open-design-v0.11.0";
+      inputs.flake-utils.follows = "flake-utils";
+      inputs.home-manager.follows = "home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     hermes-agent = {
       url = "github:NousResearch/hermes-agent";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/home/modules/default.nix
+++ b/home/modules/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     inputs.waytorandr.homeManagerModules.default
+    inputs.open-design.homeManagerModules.default
     ./dotfiles.nix
     ./packages.nix
     ./programs.nix

--- a/home/modules/services.nix
+++ b/home/modules/services.nix
@@ -459,6 +459,15 @@ in
 
         easyeffects.enable = true;
         mpris-proxy.enable = true;
+        open-design = {
+          enable = true;
+          autoStart = true;
+          webFrontend = {
+            enable = true;
+            host = "127.0.0.1";
+            port = 5174;
+          };
+        };
       };
     in
     {


### PR DESCRIPTION
## Summary

- add the Open Design flake input at the latest release tag, `open-design-v0.11.0`
- import the upstream Open Design Home Manager module
- enable Open Design only for GUI Home Manager hosts
- use the upstream Home Manager module defaults for the daemon and bundled web frontend services

## Validation

- `nix fmt --no-write-lock-file`
- `nix eval --show-trace --json --no-write-lock-file '.#homeConfigurations."jsg@amd".config.services.open-design.enable'`
- `nix eval --show-trace --json --no-write-lock-file '.#homeConfigurations."jsg@amd".config.services.open-design.autoStart'`
- `nix eval --show-trace --json --no-write-lock-file '.#homeConfigurations."jsg@amd".config.systemd.user.services.open-design.Install.WantedBy'`
- `nix eval --show-trace --json --no-write-lock-file '.#homeConfigurations."pi@raspberrypi".config.services.open-design.enable'`