### PR TITLE
Enable scheduled automatic NixOS upgrades on VM host

### DIFF
--- a/nixos/hosts/vm/base.nix
+++ b/nixos/hosts/vm/base.nix
@@ -56,6 +56,27 @@
     };
   };
 
+  system.autoUpgrade = {
+    enable = true;
+    dates = "03:00";
+    randomizedDelaySec = "30min";
+    fixedRandomDelay = true;
+    persistent = true;
+
+    flake = "github:jakob1379/nix-config#vm-docker-main";
+    flags = [ "-L" ];
+    operation = "boot";
+    upgrade = false;
+
+    allowReboot = true;
+    rebootWindow = {
+      lower = "01:00";
+      upper = "05:00";
+    };
+
+    runGarbageCollection = true;
+  };
+
   security.sudo.wheelNeedsPassword = false;
 
   environment.systemPackages = with pkgs; [


### PR DESCRIPTION
## Summary
- Enables `system.autoUpgrade` in `nixos/hosts/vm/base.nix` for the VM host.
- Schedules automatic upgrades daily at `03:00` with a fixed randomized delay of `30min`.
- Points upgrades at flake `github:jakob1379/nix-config#vm-docker-main`, runs with `-L` logging, and uses `boot` operation.
- Allows automatic reboot during a `01:00`–`05:00` window and enables persistent upgrade state.
- Adds automatic garbage collection after upgrades (`runGarbageCollection = true`).

## Testing
- Not run (configuration-only change).
- Suggested follow-up checks:
  - `nix flake check`
  - `nixos-rebuild build --flake github:jakob1379/nix-config#vm-docker-main`