### PR TITLE
Add Dockhand bootstrap auto-update timer

### DIFF
--- a/nixos/hosts/vm/README.md
+++ b/nixos/hosts/vm/README.md
@@ -8,6 +8,42 @@
 If a second VM ever appears, then split shared defaults back out. Until then,
 the extra host wrapper is just noise.
 
+## Dockhand bootstrap updates
+
+The VM owns the Dockhand bootstrap updater. Dockhand still manages the main
+homelab stack, but the Dockhand container itself is updated by a NixOS systemd
+timer.
+
+Initial checkout:
+
+```bash
+sudo git clone https://github.com/jakob1379/homelab.git /opt/homelab
+sudo docker compose -f /opt/homelab/docker-compose.pods.yml up -d
+```
+
+Timer operations:
+
+```bash
+systemctl list-timers dockhand-bootstrap-update.timer
+sudo systemctl start dockhand-bootstrap-update.service
+journalctl -u dockhand-bootstrap-update.service -n 100 --no-pager
+```
+
+Manual recovery remains:
+
+```bash
+cd /opt/homelab
+sudo docker compose -f docker-compose.pods.yml up -d
+```
+
+Deployment policy:
+
+1. Dependabot updates the homelab Docker image pins.
+2. CI passes in `homelab`.
+3. The homelab PR is merged.
+4. The VM timer fast-forwards `/opt/homelab`.
+5. Dockhand is redeployed only when the pods compose files changed.
+
 ## Build a Proxmox image
 
 `nixos-generators` is deprecated. Use the upstream image builder via

--- a/nixos/hosts/vm/base.nix
+++ b/nixos/hosts/vm/base.nix
@@ -1,9 +1,108 @@
 {
   config,
+  lib,
   modulesPath,
   pkgs,
   ...
 }:
+let
+  homelabRepo = "/opt/homelab";
+  homelabBranch = "main";
+  homelabPodsCompose = "docker-compose.pods.yml";
+
+  dockhandBootstrapUpdate = pkgs.writeShellApplication {
+    name = "dockhand-bootstrap-update";
+    runtimeInputs = with pkgs; [
+      coreutils
+      docker
+      docker-compose
+      git
+      gnugrep
+      util-linux
+    ];
+    text = ''
+      set -Eeuo pipefail
+
+      repo_dir="''${HOMELAB_REPO:-/opt/homelab}"
+      branch="''${HOMELAB_BRANCH:-main}"
+      lock_file="''${HOMELAB_LOCK_FILE:-/run/lock/homelab-dockhand-bootstrap-update.lock}"
+      compose_file="''${HOMELAB_PODS_COMPOSE:-docker-compose.pods.yml}"
+
+      log() {
+        printf '%s\n' "$*"
+      }
+
+      if ! git check-ref-format "refs/heads/$branch"; then
+        log "Invalid branch name: $branch"
+        exit 2
+      fi
+
+      exec 9>"$lock_file"
+      if ! flock -n 9; then
+        log "Another Dockhand bootstrap update is already running"
+        exit 0
+      fi
+
+      cd "$repo_dir"
+
+      current_branch="$(git branch --show-current)"
+      if [ "$current_branch" != "$branch" ]; then
+        log "Refusing to update: checkout is on '$current_branch', expected '$branch'"
+        exit 1
+      fi
+
+      dirty_status="$(git status --porcelain)"
+      if [ -n "$dirty_status" ]; then
+        log "Refusing to update dirty checkout:"
+        printf '%s\n' "$dirty_status"
+        exit 1
+      fi
+
+      before="$(git rev-parse HEAD)"
+
+      git fetch --prune origin "+refs/heads/$branch:refs/remotes/origin/$branch"
+
+      remote="$(git rev-parse "refs/remotes/origin/$branch")"
+      if [ "$before" = "$remote" ]; then
+        log "Already current at $before"
+        exit 0
+      fi
+
+      git merge --ff-only "origin/$branch"
+
+      after="$(git rev-parse HEAD)"
+      changed_paths="$(git diff --name-only "$before" "$after" --)"
+
+      log "Updated $branch from $before to $after"
+
+      watch_only_paths="$(
+        printf '%s\n' "$changed_paths" \
+          | grep -Fx -e ".env.example" -e "setup-dev.sh" -e "docs/dockhand.md" || true
+      )"
+      if [ -n "$watch_only_paths" ]; then
+        log "Watch-only paths changed:"
+        printf '%s\n' "$watch_only_paths"
+      fi
+
+      redeploy_paths="$(
+        printf '%s\n' "$changed_paths" \
+          | grep -Fx -e "$compose_file" -e "services/pods.yml" || true
+      )"
+      if [ -z "$redeploy_paths" ]; then
+        log "No Dockhand bootstrap compose changes detected; skipping redeploy"
+        exit 0
+      fi
+
+      log "Dockhand bootstrap compose paths changed:"
+      printf '%s\n' "$redeploy_paths"
+
+      docker compose -f "$compose_file" config >/dev/null
+      docker compose -f "$compose_file" pull
+      docker compose -f "$compose_file" up -d --remove-orphans
+      docker compose -f "$compose_file" ps
+    '';
+  };
+in
 {
   imports = [
     (modulesPath + "/profiles/qemu-guest.nix")
@@ -92,6 +191,46 @@
       ExecStart = "${pkgs.shadow}/bin/cha" + "ge -d 0 jsg";
     };
   };
+
+  systemd.services.dockhand-bootstrap-update = {
+    description = "Update homelab Dockhand bootstrap stack";
+    wants = [ "network-online.target" ];
+    requires = [ "docker.service" ];
+    after = [
+      "network-online.target"
+      "docker.service"
+    ];
+
+    environment = {
+      HOMELAB_REPO = homelabRepo;
+      HOMELAB_BRANCH = homelabBranch;
+      HOMELAB_PODS_COMPOSE = homelabPodsCompose;
+    };
+
+    serviceConfig = {
+      Type = "oneshot";
+      TimeoutStartSec = "10min";
+      StandardOutput = "journal";
+      StandardError = "journal";
+      SyslogIdentifier = "dockhand-bootstrap-update";
+      ExecStart = lib.getExe dockhandBootstrapUpdate;
+    };
+  };
+
+  systemd.timers.dockhand-bootstrap-update = {
+    description = "Periodically update homelab Dockhand bootstrap stack";
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnBootSec = "5min";
+      OnUnitActiveSec = "30min";
+      RandomizedDelaySec = "5min";
+      Persistent = true;
+    };
+  };
+
+  systemd.tmpfiles.rules = [
+    "d /opt/homelab 0755 root root -"
+  ];
 
   virtualisation.docker.enable = true;
 


### PR DESCRIPTION
## Summary

- Adds a NixOS timer for `/opt/homelab` Dockhand bootstrap updates
- Keeps Dockhand from self-managing its own container
- Uses fast-forward-only Git updates
- Redeploys only when pods compose files changed
- Leaves the main homelab GitOps stack under Dockhand

## Validation

- `nix fmt`
- `nix flake check --no-write-lock-file`
- `nix eval --show-trace --raw --no-write-lock-file '.#nixosConfigurations.vm-docker-main.config.system.build.toplevel.drvPath'`
- `nix build --no-write-lock-file '.#nixosConfigurations.vm-docker-main.config.system.build.toplevel' --no-link`
- `nix eval --json --no-write-lock-file '.#nixosConfigurations.vm-docker-main.config.systemd.services.dockhand-bootstrap-update.serviceConfig'`
- `nix eval --json --no-write-lock-file '.#nixosConfigurations.vm-docker-main.config.systemd.services.dockhand-bootstrap-update.environment'`
- `nix eval --json --no-write-lock-file '.#nixosConfigurations.vm-docker-main.config.systemd.timers.dockhand-bootstrap-update.timerConfig'`