### PR TITLE
Move Cachix watch-store to NixOS

### DIFF
--- a/home/modules/services.nix
+++ b/home/modules/services.nix
@@ -223,10 +223,6 @@ in
           ];
         };
 
-        cachix-agent = {
-
-        };
-
         gpg-agent = {
           enable = true;
           pinentry.package = pkgs.pinentry-gtk2;

--- a/nixos/hosts/amd/default.nix
+++ b/nixos/hosts/amd/default.nix
@@ -36,6 +36,12 @@
   # dynamic swap
   services.swapspace.enable = true;
 
+  services.cachix-watch-store = {
+    enable = true;
+    cacheName = "jgalabs-homelab";
+    cachixTokenFile = /etc/cachix-watch-store.token;
+  };
+
   # amd graphics
   boot.initrd.kernelModules = lib.mkAfter [ "amdgpu" ];
   services.xserver.videoDrivers = lib.mkAfter [ "amdgpu" ];

--- a/nixos/hosts/amd/default.nix
+++ b/nixos/hosts/amd/default.nix
@@ -39,7 +39,7 @@
   services.cachix-watch-store = {
     enable = true;
     cacheName = "jgalabs-homelab";
-    cachixTokenFile = /etc/cachix-watch-store.token;
+    cachixTokenFile = "/etc/cachix-watch-store.token";
   };
 
   # amd graphics


### PR DESCRIPTION
## Summary

- Configure the AMD host with the NixOS `services.cachix-watch-store` module.
- Point the watcher at the `jgalabs-homelab` cache.
- Use `/etc/cachix-watch-store.token` as the system token file.

## Notes

The token file must contain the raw Cachix auth token, not a `CACHIX_AUTH_TOKEN=...` environment assignment.

## Validation

- `nix build --no-write-lock-file .#nixosConfigurations.amd.config.system.build.toplevel`
- `nix build --no-write-lock-file .#homeConfigurations."jsg@amd".activationPackage`
- `git diff --check`