### PR TITLE
refactor: inline custom service definitions

### DIFF
--- a/home/modules/services.nix
+++ b/home/modules/services.nix
@@ -8,48 +8,6 @@
 }:
 
 let
-  createRcloneMountService =
-    {
-      name,
-      remote ? "${name}",
-      mountPath ? "${config.home.homeDirectory}/${name}",
-      remotePath ? "/",
-      configPath ? "${config.xdg.configHome}/rclone/rclone.conf",
-      cacheMode ? "full",
-    }:
-    {
-      Unit = {
-        Description = "Rclone mount service for ${name}";
-        After = [ "network-online.target" ];
-        Wants = [ "network-online.target" ];
-      };
-
-      Service = {
-        ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${lib.escapeShellArg mountPath}";
-        ExecStart = ''
-          ${pkgs.rclone}/bin/rclone mount \
-            --allow-other \
-            --attr-timeout 1h \
-            --buffer-size=32M \
-            --config "${configPath}" \
-            --dir-cache-time 3h0m0s \
-            --vfs-cache-max-age 6h \
-            --vfs-cache-max-size 10G \
-            --vfs-cache-mode "${cacheMode}" \
-            --vfs-fast-fingerprint \
-            ${remote}:${remotePath} ${lib.escapeShellArg mountPath}
-        '';
-        ExecStop = "fusermount -u ${lib.escapeShellArg mountPath}";
-        Type = "notify";
-        Restart = "on-failure";
-        RestartSec = "10s";
-      };
-
-      Install = {
-        WantedBy = [ "default.target" ];
-      };
-    };
-
   rcloneDropboxPrivateService = "rclone-mount-dropbox-private.service";
   dropboxPrivateMountPath = "${config.home.homeDirectory}/dropbox-private";
   varietyWallpaperPointerFile = "${config.xdg.configHome}/variety/wallpaper/wallpaper.jpg.txt";
@@ -102,114 +60,8 @@ let
 
 in
 {
-  options = {
-    customServices = {
-      storage = lib.mkOption {
-        type = lib.types.attrs;
-        default = {
-          rclone = {
-            service = {
-              rclone-mount-dropbox-private = createRcloneMountService { name = "dropbox-private"; };
-            };
-          };
-        };
-        description = "Systemd services for storage mounts.";
-      };
-
-      wallpaper = lib.mkOption {
-        type = lib.types.attrs;
-        default = {
-          varietyWallpaper = {
-            service = {
-              variety = {
-                Unit = {
-                  Description = "Variety wallpaper changer";
-                  After = [ rcloneDropboxPrivateService ];
-                  Wants = [ rcloneDropboxPrivateService ];
-                  Requires = [ rcloneDropboxPrivateService ];
-                };
-                Service = {
-                  ExecStartPre = "${pkgs.util-linux}/bin/mountpoint -q ${lib.escapeShellArg dropboxPrivateMountPath}";
-                  ExecStart = "${pkgs.variety}/bin/variety";
-                  Restart = "on-failure";
-                  RestartSec = 5;
-                };
-                Install = {
-                  WantedBy = [ "graphical-session.target" ];
-                };
-              };
-
-              "variety-wallpaper-sync" = {
-                Unit = {
-                  Description = "Sync Noctalia and terminal colors from Variety wallpaper";
-                  After = [ rcloneDropboxPrivateService ];
-                  Wants = [ rcloneDropboxPrivateService ];
-                  Requires = [ rcloneDropboxPrivateService ];
-                };
-                Service = {
-                  ExecStart = varietyWallpaperStateSyncCommand;
-                  TimeoutStartSec = 60;
-                  Type = "oneshot";
-                };
-                Install = {
-                  WantedBy = [ "graphical-session.target" ];
-                };
-              };
-            };
-
-            path = {
-              "variety-wallpaper-sync" = {
-                Unit = {
-                  Description = "Watch Variety wallpaper pointer for Noctalia and terminal colors";
-                  After = [ rcloneDropboxPrivateService ];
-                  Wants = [
-                    "variety-wallpaper-sync.service"
-                    rcloneDropboxPrivateService
-                  ];
-                  Requires = [ rcloneDropboxPrivateService ];
-                };
-                Install = {
-                  WantedBy = [ "graphical-session.target" ];
-                };
-                Path = {
-                  PathChanged = varietyWallpaperPointerFile;
-                };
-              };
-            };
-          };
-        };
-        description = "Systemd services for wallpaper state.";
-      };
-
-      desktop = lib.mkOption {
-        type = lib.types.attrs;
-        default = {
-          niriWindowBorders = {
-            "niri-window-border-rules" = {
-              Unit = {
-                Description = "Sync per-window hashed border rules for Niri";
-                After = [ "graphical-session.target" ];
-              };
-              Install = {
-                WantedBy = [ "graphical-session.target" ];
-              };
-              Service = {
-                ExecCondition = niriSessionExecCondition;
-                ExecStart = niriWindowBorderRulesWatchCommand;
-                Restart = "always";
-                RestartSec = 2;
-              };
-            };
-          };
-        };
-        description = "Systemd services for desktop integration.";
-      };
-    };
-  };
-
   config =
     let
-      cfg = config.customServices;
       coreServices = {
         emacs = {
           package = pkgs.emacs31-pgtk;
@@ -269,16 +121,116 @@ in
           startServices = true;
 
           services = lib.mkMerge [
-            (lib.mkIf config.customPackages.gui.enable (cfg.storage.rclone.service or { }))
-            (lib.mkIf config.customPackages.gui.enable (cfg.wallpaper.varietyWallpaper.service or { }))
-            (lib.mkIf config.customPackages.gui.enable cfg.desktop.niriWindowBorders)
+            (lib.mkIf config.customPackages.gui.enable {
+              rclone-mount-dropbox-private = {
+                Unit = {
+                  Description = "Rclone mount service for dropbox-private";
+                  After = [ "network-online.target" ];
+                  Wants = [ "network-online.target" ];
+                };
+
+                Service = {
+                  ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${lib.escapeShellArg dropboxPrivateMountPath}";
+                  ExecStart = ''
+                    ${pkgs.rclone}/bin/rclone mount \
+                      --allow-other \
+                      --attr-timeout 1h \
+                      --buffer-size=32M \
+                      --config "${config.xdg.configHome}/rclone/rclone.conf" \
+                      --dir-cache-time 3h0m0s \
+                      --vfs-cache-max-age 6h \
+                      --vfs-cache-max-size 10G \
+                      --vfs-cache-mode "full" \
+                      --vfs-fast-fingerprint \
+                      dropbox-private:/ ${lib.escapeShellArg dropboxPrivateMountPath}
+                  '';
+                  ExecStop = "fusermount -u ${lib.escapeShellArg dropboxPrivateMountPath}";
+                  Type = "notify";
+                  Restart = "on-failure";
+                  RestartSec = "10s";
+                };
+
+                Install = {
+                  WantedBy = [ "default.target" ];
+                };
+              };
+
+              variety = {
+                Unit = {
+                  Description = "Variety wallpaper changer";
+                  After = [ rcloneDropboxPrivateService ];
+                  Wants = [ rcloneDropboxPrivateService ];
+                  Requires = [ rcloneDropboxPrivateService ];
+                };
+                Service = {
+                  ExecStartPre = "${pkgs.util-linux}/bin/mountpoint -q ${lib.escapeShellArg dropboxPrivateMountPath}";
+                  ExecStart = "${pkgs.variety}/bin/variety";
+                  Restart = "on-failure";
+                  RestartSec = 5;
+                };
+                Install = {
+                  WantedBy = [ "graphical-session.target" ];
+                };
+              };
+
+              "variety-wallpaper-sync" = {
+                Unit = {
+                  Description = "Sync Noctalia and terminal colors from Variety wallpaper";
+                  After = [ rcloneDropboxPrivateService ];
+                  Wants = [ rcloneDropboxPrivateService ];
+                  Requires = [ rcloneDropboxPrivateService ];
+                };
+                Service = {
+                  ExecStart = varietyWallpaperStateSyncCommand;
+                  TimeoutStartSec = 60;
+                  Type = "oneshot";
+                };
+                Install = {
+                  WantedBy = [ "graphical-session.target" ];
+                };
+              };
+
+              "niri-window-border-rules" = {
+                Unit = {
+                  Description = "Sync per-window hashed border rules for Niri";
+                  After = [ "graphical-session.target" ];
+                };
+                Install = {
+                  WantedBy = [ "graphical-session.target" ];
+                };
+                Service = {
+                  ExecCondition = niriSessionExecCondition;
+                  ExecStart = niriWindowBorderRulesWatchCommand;
+                  Restart = "always";
+                  RestartSec = 2;
+                };
+              };
+            })
             (lib.mkIf config.services.swayidle.enable {
               swayidle.Service.ExecCondition = niriSessionExecCondition;
             })
           ];
 
           paths = lib.mkMerge [
-            (lib.mkIf config.customPackages.gui.enable (cfg.wallpaper.varietyWallpaper.path or { }))
+            (lib.mkIf config.customPackages.gui.enable {
+              "variety-wallpaper-sync" = {
+                Unit = {
+                  Description = "Watch Variety wallpaper pointer for Noctalia and terminal colors";
+                  After = [ rcloneDropboxPrivateService ];
+                  Wants = [
+                    "variety-wallpaper-sync.service"
+                    rcloneDropboxPrivateService
+                  ];
+                  Requires = [ rcloneDropboxPrivateService ];
+                };
+                Install = {
+                  WantedBy = [ "graphical-session.target" ];
+                };
+                Path = {
+                  PathChanged = varietyWallpaperPointerFile;
+                };
+              };
+            })
           ];
         };
       };

--- a/home/modules/services.nix
+++ b/home/modules/services.nix
@@ -8,6 +8,48 @@
 }:
 
 let
+  createRcloneMountService =
+    {
+      name,
+      remote ? "${name}",
+      mountPath ? "${config.home.homeDirectory}/${name}",
+      remotePath ? "/",
+      configPath ? "${config.xdg.configHome}/rclone/rclone.conf",
+      cacheMode ? "full",
+    }:
+    {
+      Unit = {
+        Description = "Rclone mount service for ${name}";
+        After = [ "network-online.target" ];
+        Wants = [ "network-online.target" ];
+      };
+
+      Service = {
+        ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${lib.escapeShellArg mountPath}";
+        ExecStart = ''
+          ${pkgs.rclone}/bin/rclone mount \
+            --allow-other \
+            --attr-timeout 1h \
+            --buffer-size=32M \
+            --config "${configPath}" \
+            --dir-cache-time 3h0m0s \
+            --vfs-cache-max-age 6h \
+            --vfs-cache-max-size 10G \
+            --vfs-cache-mode "${cacheMode}" \
+            --vfs-fast-fingerprint \
+            ${remote}:${remotePath} ${lib.escapeShellArg mountPath}
+        '';
+        ExecStop = "fusermount -u ${lib.escapeShellArg mountPath}";
+        Type = "notify";
+        Restart = "on-failure";
+        RestartSec = "10s";
+      };
+
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
+    };
+
   rcloneDropboxPrivateService = "rclone-mount-dropbox-private.service";
   dropboxPrivateMountPath = "${config.home.homeDirectory}/dropbox-private";
   varietyWallpaperPointerFile = "${config.xdg.configHome}/variety/wallpaper/wallpaper.jpg.txt";
@@ -122,38 +164,7 @@ in
 
           services = lib.mkMerge [
             (lib.mkIf config.customPackages.gui.enable {
-              rclone-mount-dropbox-private = {
-                Unit = {
-                  Description = "Rclone mount service for dropbox-private";
-                  After = [ "network-online.target" ];
-                  Wants = [ "network-online.target" ];
-                };
-
-                Service = {
-                  ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${lib.escapeShellArg dropboxPrivateMountPath}";
-                  ExecStart = ''
-                    ${pkgs.rclone}/bin/rclone mount \
-                      --allow-other \
-                      --attr-timeout 1h \
-                      --buffer-size=32M \
-                      --config "${config.xdg.configHome}/rclone/rclone.conf" \
-                      --dir-cache-time 3h0m0s \
-                      --vfs-cache-max-age 6h \
-                      --vfs-cache-max-size 10G \
-                      --vfs-cache-mode "full" \
-                      --vfs-fast-fingerprint \
-                      dropbox-private:/ ${lib.escapeShellArg dropboxPrivateMountPath}
-                  '';
-                  ExecStop = "fusermount -u ${lib.escapeShellArg dropboxPrivateMountPath}";
-                  Type = "notify";
-                  Restart = "on-failure";
-                  RestartSec = "10s";
-                };
-
-                Install = {
-                  WantedBy = [ "default.target" ];
-                };
-              };
+              rclone-mount-dropbox-private = createRcloneMountService { name = "dropbox-private"; };
 
               variety = {
                 Unit = {


### PR DESCRIPTION
## Summary
- Remove the one-consumer `customServices` option abstraction.
- Inline the equivalent user service and path definitions in `home/modules/services.nix`.
- Keep existing Niri window border service wiring intact.

## Checks
- `git diff --check`
- `nix eval '.#homeConfigurations."jsg@amd".activationPackage.drvPath' --raw`