### PR TITLE
Simplify noqa-stats output

### DIFF
--- a/bin/noqa-stats
+++ b/bin/noqa-stats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -uo pipefail
+set -euo pipefail
 IFS=$'\n\t'
 
 script_name="${0##*/}"
@@ -9,14 +9,14 @@ usage() {
 	cat <<EOF
 Usage: ${script_name} [DIR] [OPTIONS]
 
-Analyze noqa comments in Python files and display statistics.
+Count noqa-style comments in files.
 
 ARGUMENTS:
-   DIR             Directory to search (default: current directory)
+   DIR             Directory to search (default: .)
 
 OPTIONS:
    -h, --help      Show this help message and exit
-   -d, --dir DIR   Search in DIR instead of current directory
+   -d, --dir DIR   Search in DIR instead of .
    -p, --pattern   Pattern to search (default: "# noqa")
 
 EXAMPLES:
@@ -24,166 +24,33 @@ EXAMPLES:
    ${script_name} ./backend
    ${script_name} --dir ./backend
    ${script_name} ./backend --pattern "type: ignore"
-
 EOF
 }
 
-print_rule_totals() {
+print_rules() {
 	local raw_data="$1"
 	local pattern="$2"
 
-	# Fancy header with border and icon
-	gum style \
-		--border double \
-		--border-foreground 212 \
-		--margin "1 0" \
-		--padding "0 2" \
-		--align center \
-		"📊  $(gum style --foreground 212 --bold "Rule Totals")  📊"
+	awk -v pattern="${pattern}" '
+		match($0, pattern) {
+			content = substr($0, RSTART + RLENGTH)
+			sub(/^[ \t:]*/, "", content)
+			sub(/#.*/, "", content)
+			gsub(/^[ \t]+|[ \t]+$/, "", content)
 
-	# Subtitle
-	gum style --foreground 240 --italic "  Visual breakdown of noqa suppression rules"
+			if (content == "") {
+				print "(bare)"
+				next
+			}
 
-	# First pass: collect counts and find max
-	local counts_data
-	counts_data=$(awk -v pattern="${pattern}" '{
-       if (match($0, pattern)) {
-           content = substr($0, RSTART + RLENGTH)
-           sub(/^[ \t:]*/, "", content)
-           sub(/#.*/, "", content)
-           sub(/[ \t]*$/, "", content)
-           n = split(content, parts, /[ \t]*,[ \t]*|[ \t]+/)
-           for (i=1; i<=n; i++) {
-               rule = parts[i]
-               gsub(/^[\047"]+|[\047"]+$/, "", rule)
-               if (rule != "" && rule !~ /^#/) count[rule]++
-           }
-       }
-   } END {
-       max = 0
-       for (rule in count) {
-           if (count[rule] > max) max = count[rule]
-           printf "%s\t%d\n", rule, count[rule]
-       }
-       print "MAX:\t" max
-   }' <<<"${raw_data}" | sort -t$'\t' -k2 -nr)
-
-	# Extract max count
-	local max_count
-	max_count=$(awk -F'\t' '$1 == "MAX:" {print $2; exit}' <<<"${counts_data}")
-
-	# Generate table with styled count + gradient bar
-	grep -v "^MAX:" <<<"${counts_data}" | awk -F'\t' -v max="${max_count}" 'BEGIN { OFS="\t" }
-   {
-       rule = $1
-       count = $2
-       bar_width = 0
-       if (max > 0) {
-           bar_width = int(count * 12 / max)
-           if (bar_width == 0 && count > 0) bar_width = 1
-       }
-       bar = ""
-       for (i=1; i<=bar_width; i++) bar = bar "▓"
-       # Pad bar to 12 chars for alignment
-       while (length(bar) < 12) bar = bar "░"
-       print rule, count, bar
-   }' | gum table --print --separator $'\t' \
-		--columns "Rule,Count,Distribution" \
-		--widths 25,6,15
-}
-
-print_file_counts() {
-	local raw_data="$1"
-	local pattern="$2"
-	local max_file_width="${3:-48}"
-	local term_width
-	term_width="$(tput cols 2>/dev/null || echo 100)"
-
-	# Adjust widths based on terminal size
-	local rules_width=45
-	if [[ $term_width -lt 100 ]]; then
-		max_file_width=30
-		rules_width=30
-	fi
-
-	# Fancy header with border and icon
-	gum style \
-		--border double \
-		--border-foreground 141 \
-		--margin "1 0 0 0" \
-		--padding "0 2" \
-		--align center \
-		"📁  $(gum style --foreground 141 --bold "Per-File Breakdown")  📁"
-
-	# Subtitle
-	gum style --foreground 240 --italic "  Files ranked by noqa count, with rule distribution"
-
-	awk -F':' -v pattern="${pattern}" '
-    {
-        file=$1
-        if (match($0, pattern)) {
-            content = substr($0, RSTART + RLENGTH)
-            sub(/^[ \t:]*/, "", content)
-            sub(/#.*/, "", content)
-            gsub(/^[ \t]+|[ \t]+$/, "", content)
-            # Split on comma or space
-            n = split(content, parts, /[ \t]*,[ \t]*|[ \t]+/)
-            for (i=1; i<=n; i++) {
-                rule = parts[i]
-                gsub(/^[\047"]+|[\047"]+$/, "", rule)
-                if (rule != "" && rule !~ /^#/) {
-                    key = file "\t" rule
-                    counts[key]++
-                    totals[file]++
-                }
-            }
-        }
-    }
-    END {
-        for (key in counts) {
-            split(key, p, "\t")
-            printf "%s\t%s\t%d\t%d\n", p[1], p[2], counts[key], totals[p[1]]
-        }
-    }' \
-		<<<"${raw_data}" \
-		| sort -t$'\t' -k1,1 -k3,3nr \
-		| awk -v max_rule_len="$((rules_width - 3))" -v max_file_len="$max_file_width" -F'\t' '
-    BEGIN { OFS="\t" }
-    {
-        if ($1 != prev && prev != "") print_row()
-        prev = $1
-        prev_total = $4
-        rules[++n] = $2
-        rule_counts[n] = $3
-    }
-    END { print_row() }
-
-    function print_row() {
-        formatted = ""
-        visible = 0
-        for (i=1; i<=n; i++) {
-            entry = rules[i] ": " rule_counts[i]
-            test = formatted (formatted ? ", " : "") entry
-            if (length(test) > max_rule_len && i > 1) {
-                formatted = formatted ", +" (n-visible) " more"
-                break
-            }
-            formatted = test
-            visible++
-        }
-
-        f = prev
-        if (length(f) > max_file_len) {
-            f = "..." substr(f, length(f) - max_file_len + 4)
-        }
-
-        print f, formatted, prev_total
-        delete rules; delete rule_counts; n = 0
-    }' \
-		| sort -t$'\t' -k3 -nr \
-		| gum table --print --separator $'\t' \
-			--columns "File,Rules,Total" \
-			--widths "$max_file_width,$rules_width,8"
+			n = split(content, parts, /[ \t]*,[ \t]*|[ \t]+/)
+			for (i = 1; i <= n; i++) {
+				rule = parts[i]
+				gsub(/^[\047"]+|[\047"]+$/, "", rule)
+				if (rule != "" && rule !~ /^#/) print rule
+			}
+		}
+	' <<<"${raw_data}" | sort | uniq -c | sort -nr
 }
 
 main() {
@@ -191,35 +58,25 @@ main() {
 	local pattern="# noqa"
 
 	while [[ $# -gt 0 ]]; do
-		case $1 in
+		case "$1" in
 			-h | --help)
 				usage
 				exit 0
 				;;
 			-d | --dir)
-				if [[ $# -lt 2 ]]; then
-					echo "Error: --dir requires a value" >&2
-					usage >&2
-					exit 1
-				fi
-				search_dir="$2"
-				if [[ -z "${search_dir}" ]]; then
+				if [[ $# -lt 2 || -z "${2:-}" ]]; then
 					echo "Error: --dir requires a non-empty value" >&2
 					exit 1
 				fi
+				search_dir="$2"
 				shift 2
 				;;
 			-p | --pattern)
-				if [[ $# -lt 2 ]]; then
-					echo "Error: --pattern requires a value" >&2
-					usage >&2
-					exit 1
-				fi
-				pattern="$2"
-				if [[ -z "${pattern}" ]]; then
+				if [[ $# -lt 2 || -z "${2:-}" ]]; then
 					echo "Error: --pattern requires a non-empty value" >&2
 					exit 1
 				fi
+				pattern="$2"
 				shift 2
 				;;
 			-*)
@@ -228,7 +85,6 @@ main() {
 				exit 1
 				;;
 			*)
-				# Positional argument - use as directory
 				search_dir="$1"
 				shift
 				;;
@@ -241,9 +97,13 @@ main() {
 	fi
 
 	local raw_data rg_status rg_stderr
-	rg_stderr=$(mktemp)
-	raw_data=$(gum spin --spinner dot --title "Scanning for '${pattern}' in ${search_dir}..." -- rg --color=never --line-number --with-filename --no-heading -e "${pattern}" "${search_dir}" 2>"${rg_stderr}")
-	rg_status=$?
+	rg_stderr="$(mktemp)"
+	if raw_data="$(rg --color=never --line-number --with-filename --no-heading -e "${pattern}" "${search_dir}" 2>"${rg_stderr}")"; then
+		rg_status=0
+	else
+		rg_status=$?
+	fi
+
 	if [[ ${rg_status} -eq 1 ]]; then
 		raw_data=""
 	elif [[ ${rg_status} -ne 0 ]]; then
@@ -255,62 +115,23 @@ main() {
 	rm -f "${rg_stderr}"
 
 	if [[ -z "${raw_data}" ]]; then
-		# Success state with nice styling
-		gum style \
-			--border rounded \
-			--border-foreground 82 \
-			--margin "1" \
-			--padding "1 2" \
-			"$(gum style --foreground 82 --bold "✓  All Clear")" \
-			"" \
-			"$(gum style --foreground 250 "   No '${pattern}' comments found in ${search_dir}")"
+		echo "No matches for '${pattern}' in ${search_dir}"
 		exit 0
 	fi
 
-	local total_rules total_files
-	total_rules=$(wc -l <<<"${raw_data}")
-	total_files=$(cut -d: -f1 <<<"${raw_data}" | sort -u | wc -l)
+	local total_matches total_files
+	total_matches="$(wc -l <<<"${raw_data}")"
+	total_files="$(cut -d: -f1 <<<"${raw_data}" | sort -u | wc -l)"
 
-	local unique_rules
-	unique_rules=$(awk -v pattern="${pattern}" '{
-       if (match($0, pattern)) {
-           content = substr($0, RSTART + RLENGTH)
-           sub(/^[ \t:]*/, "", content)
-           sub(/#.*/, "", content)
-           sub(/[ \t]*$/, "", content)
-           n = split(content, parts, /[ \t]*,[ \t]*|[ \t]+/)
-           for (i=1; i<=n; i++) {
-               rule = parts[i]
-               gsub(/^[\047"]+|[\047"]+$/, "", rule)
-               if (rule != "" && rule !~ /^#/) print rule
-           }
-       }
-   }' <<<"${raw_data}" | sort -u | wc -l)
+	printf 'Directory: %s\n' "${search_dir}"
+	printf 'Pattern: %s\n' "${pattern}"
+	printf 'Matches: %s\n' "${total_matches}"
+	printf 'Files: %s\n\n' "${total_files}"
 
-	gum style \
-		--border double \
-		--border-foreground 212 \
-		--background 234 \
-		--margin "1 0" \
-		--padding "1 4" \
-		--align center \
-		"$(gum style --foreground 212 --bold "✨  NOQA Scan")" \
-		"$(gum style --foreground 240 "${search_dir}")" \
-		"" \
-		"$(gum style --foreground 183 --bold "${total_rules} suppressions    ${total_files} files    ${unique_rules} rules")" \
-		"$(gum style --foreground 240 --italic "Pattern: ${pattern}    $(date '+%H:%M:%S')")"
-
-	print_rule_totals "${raw_data}" "${pattern}"
-
-	# Decorative separator
-	local term_width
-	term_width=$(tput cols 2>/dev/null || echo 80)
-	local separator
-	printf -v separator '%*s' "$((term_width - 4))" ''
-	separator=${separator// /─}
-	gum style --foreground 240 --margin "1 0" "  ${separator}"
-
-	print_file_counts "${raw_data}" "${pattern}"
+	echo "Rule counts:"
+	print_rules "${raw_data}" "${pattern}"
+	printf '\nFile counts:\n'
+	cut -d: -f1 <<<"${raw_data}" | sort | uniq -c | sort -nr
 }
 
 main "$@"

--- a/home/modules/package-sets.nix
+++ b/home/modules/package-sets.nix
@@ -272,8 +272,8 @@
     (pkgs.writeShellApplication {
       name = "noqa-stats";
       runtimeInputs = [
-        pkgs.gum
-        pkgs.gnugrep
+        pkgs.coreutils
+        pkgs.gawk
         pkgs.ripgrep
       ];
       text = builtins.readFile ../../bin/noqa-stats;


### PR DESCRIPTION
## Summary
- Replace the styled `noqa-stats` dashboard with plain text counts.
- Drop unused `gum` and `gnugrep` runtime dependencies from the Home Manager package set.

## Checks
- `git diff --check`
- `bash -n bin/noqa-stats`
- temp-dir smoke test with one `# noqa: F401`
- `nix eval --show-trace --raw --no-write-lock-file '.#homeConfigurations."jsg@amd".activationPackage.drvPath'`