### PR TITLE
refactor: reuse hsu in update-all

### DIFF
--- a/bin/update-all
+++ b/bin/update-all
@@ -1,29 +1,20 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 flakePath="${XDG_CONFIG_HOME:-$HOME/.config}/home-manager"
 
-if command -v gh >/dev/null 2>&1 && [[ "${NIX_CONFIG:-}" != *"github.com="* ]]; then
-	githubToken="$(gh auth token -h github.com 2>/dev/null || true)"
-	if [[ -n "$githubToken" ]]; then
-		export NIX_CONFIG="access-tokens = github.com=$githubToken"
-	fi
-fi
-
-# Parallel updates
 sudo -v
-sudo nix-channel --update &
-nix flake update --flake "${flakePath}" &
 nix-channel --update &
+sudo nix-channel --update &
 wait
-# Home Manager switch with output monitor
-home-manager switch --flake "${flakePath}" "$@" |& nom
+
+hsu "$@"
 
 uv tool upgrade --all &
-rm -rf ~/.cache/opencode
+rm -rf "$HOME/.cache/opencode"
 opencode models --refresh &
 
 wait
 
-# NixOS switch with output monitor
 sudo -v
 nixos-rebuild switch --sudo --flake "${flakePath}" |& nom

--- a/home/modules/package-sets.nix
+++ b/home/modules/package-sets.nix
@@ -5,6 +5,17 @@
   ...
 }:
 
+let
+  hsu = pkgs.writeShellApplication {
+    name = "hsu";
+    runtimeInputs = [
+      pkgs.gh
+      pkgs.home-manager
+      pkgs.nix-output-monitor
+    ];
+    text = builtins.readFile ../../bin/hm-switch-update;
+  };
+in
 {
   core = with pkgs; [
     btop
@@ -203,15 +214,7 @@
       ];
       text = builtins.readFile ../../bin/hm-switch;
     })
-    (pkgs.writeShellApplication {
-      name = "hsu";
-      runtimeInputs = [
-        pkgs.gh
-        pkgs.home-manager
-        pkgs.nix-output-monitor
-      ];
-      text = builtins.readFile ../../bin/hm-switch-update;
-    })
+    hsu
     (pkgs.writeShellApplication {
       name = "nix-find";
       runtimeInputs = [
@@ -247,9 +250,13 @@
     (pkgs.writeShellApplication {
       name = "update-all";
       runtimeInputs = [
-        pkgs.gh
-        pkgs.home-manager
+        hsu
+        pkgs.coreutils
+        pkgs.nix
         pkgs.nix-output-monitor
+        pkgs.nixos-rebuild
+        pkgs.opencode
+        pkgs.sudo
         pkgs.uv
       ];
       text = builtins.readFile ../../bin/update-all;


### PR DESCRIPTION
## Summary
- shrink update-all by delegating the Home Manager switch/update step to hsu
- hoist the existing hsu wrapper so update-all can use it as a runtime input
- keep update-all runtime inputs aligned with the commands it still runs

## Checks
- git diff --check
- bash -n bin/update-all
- nix eval .#homeConfigurations."jsg@amd".activationPackage.drvPath