### PR TITLE
feat(niri): add low-battery border alarm

### DIFF
--- a/dotfiles/niri/config.kdl
+++ b/dotfiles/niri/config.kdl
@@ -693,6 +693,9 @@ binds {
     Mod+Shift+P { power-off-monitors; }
 }
 
+// Noctalia's battery hooks update this state file as charge falls.
+include optional=true "~/.local/state/niri/battery-border.kdl"
+
 
 // Local Variables:
 // mode: java

--- a/home/modules/programs.nix
+++ b/home/modules/programs.nix
@@ -25,6 +25,11 @@ let
     ];
     text = builtins.readFile ../../scripts/tmux/window-label.sh;
   };
+  updateBatteryBorder = pkgs.writeShellApplication {
+    name = "update-battery-border";
+    runtimeInputs = [ pkgs.coreutils ];
+    text = builtins.readFile ../../scripts/desktop/update-battery-border.sh;
+  };
 in
 {
   imports = [
@@ -351,6 +356,16 @@ in
             };
 
             backdrop.enabled = false;
+
+            battery.warning_threshold = 20;
+
+            hooks = {
+              started = "${updateBatteryBorder}/bin/update-battery-border";
+              battery_charging = "${updateBatteryBorder}/bin/update-battery-border";
+              battery_discharging = "${updateBatteryBorder}/bin/update-battery-border";
+              battery_percentage_changed = "${updateBatteryBorder}/bin/update-battery-border";
+              battery_plugged = "${updateBatteryBorder}/bin/update-battery-border";
+            };
 
             bar.main = {
               position = "top";

--- a/scripts/desktop/update-battery-border.sh
+++ b/scripts/desktop/update-battery-border.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -eu
+
+override_file="$HOME/.local/state/niri/battery-border.kdl"
+
+read_battery() {
+  local battery=""
+
+  if [[ "${NOCTALIA_BATTERY_PERCENT:-}" =~ ^[0-9]+$ ]]; then
+    percent="$NOCTALIA_BATTERY_PERCENT"
+    battery_state="${NOCTALIA_BATTERY_STATE:-unknown}"
+    return
+  fi
+
+  for battery in /sys/class/power_supply/BAT*; do
+    [ -d "$battery" ] || continue
+    IFS= read -r percent < "$battery/capacity"
+    IFS= read -r battery_state < "$battery/status"
+    return
+  done
+
+  percent=""
+  battery_state="unknown"
+}
+
+write_override() {
+  local directory="${override_file%/*}"
+  local temporary=""
+
+  mkdir -p "$directory"
+  temporary="$(mktemp "$override_file.XXXXXX")"
+  trap 'rm -f "$temporary"' EXIT
+  cat > "$temporary"
+  mv "$temporary" "$override_file"
+  trap - EXIT
+}
+
+render_alarm() {
+  local progress=$((20 - percent))
+  local active_green=$((176 - (107 * progress / 9)))
+  local active_blue=$((0 + (58 * progress / 9)))
+  local inactive_red=$((107 + (15 * progress / 9)))
+  local inactive_green=$((75 - (44 * progress / 9)))
+  local inactive_blue=$((0 + (26 * progress / 9)))
+  local active=""
+  local inactive=""
+
+  printf -v active '#ff%02x%02x' "$active_green" "$active_blue"
+  printf -v inactive '#%02x%02x%02x' "$inactive_red" "$inactive_green" "$inactive_blue"
+
+  cat <<EOF
+layout {
+    border {
+        active-color "$active"
+        inactive-color "$inactive"
+    }
+}
+EOF
+}
+
+read_battery
+battery_state="${battery_state,,}"
+battery_state="${battery_state// /_}"
+
+if ! [[ "$percent" =~ ^[0-9]+$ ]] || [ "$percent" -gt 20 ] || [[ "$battery_state" != "discharging" && "$battery_state" != "pending_discharge" ]]; then
+  printf '// Low-battery border inactive.\n' | write_override
+elif [ "$percent" -le 10 ]; then
+  cat <<'EOF' | write_override
+layout {
+    border {
+        active-gradient from="#ff9500" to="#ff2d55" angle=90 relative-to="workspace-view"
+        inactive-gradient from="#7a1f1a" to="#4a0b12" angle=90 relative-to="workspace-view"
+    }
+}
+EOF
+else
+  render_alarm | write_override
+fi


### PR DESCRIPTION
## Summary

- raise Noctalia's low-battery warning threshold to 20%
- update a hot-reloaded Niri border override from native Noctalia battery hooks
- transition from amber to red between 20% and 11%, then use a hot gradient at 10% and below
- restore the normal border immediately while charging or above the threshold

## Validation

- generated and validated Niri overrides for 21%, 20%, 15%, 11%, 10%, and 5%, plus charging states
- validated the Niri base config with the optional state include
- validated the exact generated Noctalia config for both laptop profiles
- built `jsg@amd` and `jga@yoga` Home Manager activation packages
- ran the configured repository checks with `nix develop -c prek run`