### PR TITLE
feat(desktop): add low-battery screen ring

### DIFF
--- a/dotfiles/niri/config.kdl
+++ b/dotfiles/niri/config.kdl
@@ -693,10 +693,6 @@ binds {
     Mod+Shift+P { power-off-monitors; }
 }
 
-// Noctalia's battery hooks update this state file as charge falls.
-include optional=true "~/.local/state/niri/battery-border.kdl"
-
-
 // Local Variables:
 // mode: java
 // End:

--- a/home/modules/programs.nix
+++ b/home/modules/programs.nix
@@ -25,9 +25,28 @@ let
     ];
     text = builtins.readFile ../../scripts/tmux/window-label.sh;
   };
+  batteryScreenBorder =
+    pkgs.runCommandCC "battery-screen-border"
+      {
+        nativeBuildInputs = [ pkgs.pkg-config ];
+        buildInputs = [
+          pkgs.gtk3
+          pkgs.gtk-layer-shell
+        ];
+      }
+      ''
+        mkdir -p "$out/bin"
+        $CC -Wall -Wextra -Werror $(pkg-config --cflags gtk+-3.0 gtk-layer-shell-0) \
+          ${../../scripts/desktop/battery-screen-border.c} \
+          -o "$out/bin/battery-screen-border" \
+          $(pkg-config --libs gtk+-3.0 gtk-layer-shell-0)
+      '';
   updateBatteryBorder = pkgs.writeShellApplication {
     name = "update-battery-border";
-    runtimeInputs = [ pkgs.coreutils ];
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.systemd
+    ];
     text = builtins.readFile ../../scripts/desktop/update-battery-border.sh;
   };
 in
@@ -56,6 +75,12 @@ in
         default = true;
         description = "Enable KeepassXC integration for SSH connections.";
       };
+    };
+
+    customBattery.warningThreshold = lib.mkOption {
+      type = lib.types.ints.between 12 100;
+      default = 20;
+      description = "Battery percentage at which low-battery warnings start.";
     };
   };
 
@@ -115,6 +140,7 @@ in
           };
         };
       };
+      batteryWarningThreshold = toString config.customBattery.warningThreshold;
       sshSocketDir = config.home.homeDirectory + "/.ssh/sockets";
     in
     {
@@ -129,6 +155,19 @@ in
 
         file = lib.optionalAttrs config.customSsh.enableKeepassxc {
           ".ssh/keepassxc-prompt".source = ../../scripts/ssh/keepassxc-prompt.sh;
+        };
+      };
+
+      systemd.user.services.battery-screen-border = lib.mkIf config.customPackages.gui.enable {
+        Unit = {
+          Description = "Show the low-battery screen border";
+          After = [ "graphical-session.target" ];
+          PartOf = [ "graphical-session.target" ];
+        };
+        Service = {
+          ExecStart = "${batteryScreenBorder}/bin/battery-screen-border %t/battery-screen-border";
+          Restart = "on-failure";
+          RestartSec = 1;
         };
       };
 
@@ -365,14 +404,14 @@ in
 
             backdrop.enabled = false;
 
-            battery.warning_threshold = 20;
+            battery.warning_threshold = config.customBattery.warningThreshold;
 
             hooks = {
-              started = "${updateBatteryBorder}/bin/update-battery-border";
-              battery_charging = "${updateBatteryBorder}/bin/update-battery-border";
-              battery_discharging = "${updateBatteryBorder}/bin/update-battery-border";
-              battery_percentage_changed = "${updateBatteryBorder}/bin/update-battery-border";
-              battery_plugged = "${updateBatteryBorder}/bin/update-battery-border";
+              started = "${updateBatteryBorder}/bin/update-battery-border ${batteryWarningThreshold}";
+              battery_charging = "${updateBatteryBorder}/bin/update-battery-border ${batteryWarningThreshold}";
+              battery_discharging = "${updateBatteryBorder}/bin/update-battery-border ${batteryWarningThreshold}";
+              battery_percentage_changed = "${updateBatteryBorder}/bin/update-battery-border ${batteryWarningThreshold}";
+              battery_plugged = "${updateBatteryBorder}/bin/update-battery-border ${batteryWarningThreshold}";
             };
 
             bar.main = {

--- a/scripts/desktop/battery-screen-border.c
+++ b/scripts/desktop/battery-screen-border.c
@@ -1,0 +1,135 @@
+#include <gtk-layer-shell.h>
+#include <gtk/gtk.h>
+
+#include <stdio.h>
+
+typedef struct {
+  int width;
+  GdkRGBA from;
+  GdkRGBA to;
+  GList *windows;
+} BorderState;
+
+static gboolean draw_border(GtkWidget *widget, cairo_t *context, gpointer data) {
+  const BorderState *state = data;
+  const double width = gtk_widget_get_allocated_width(widget);
+  const double height = gtk_widget_get_allocated_height(widget);
+  const double inset = state->width / 2.0;
+  cairo_pattern_t *gradient = cairo_pattern_create_linear(0.0, 0.0, width, height);
+
+  cairo_set_operator(context, CAIRO_OPERATOR_SOURCE);
+  cairo_set_source_rgba(context, 0.0, 0.0, 0.0, 0.0);
+  cairo_paint(context);
+  cairo_set_operator(context, CAIRO_OPERATOR_OVER);
+
+  cairo_pattern_add_color_stop_rgba(
+      gradient, 0.0, state->from.red, state->from.green, state->from.blue, state->from.alpha
+  );
+  cairo_pattern_add_color_stop_rgba(
+      gradient, 1.0, state->to.red, state->to.green, state->to.blue, state->to.alpha
+  );
+  cairo_set_source(context, gradient);
+  cairo_set_line_width(context, state->width);
+  cairo_rectangle(context, inset, inset, width - state->width, height - state->width);
+  cairo_stroke(context);
+  cairo_pattern_destroy(gradient);
+
+  return TRUE;
+}
+
+static void make_click_through(GtkWidget *widget, gpointer data) {
+  cairo_region_t *empty = cairo_region_create();
+
+  (void)data;
+  gdk_window_input_shape_combine_region(gtk_widget_get_window(widget), empty, 0, 0);
+  cairo_region_destroy(empty);
+}
+
+static GtkWidget *create_window(GdkMonitor *monitor, BorderState *state) {
+  GtkWidget *window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+  GdkVisual *visual = gdk_screen_get_rgba_visual(gtk_widget_get_screen(window));
+
+  if (visual != NULL) {
+    gtk_widget_set_visual(window, visual);
+  }
+  gtk_widget_set_app_paintable(window, TRUE);
+  gtk_window_set_accept_focus(GTK_WINDOW(window), FALSE);
+  gtk_window_set_decorated(GTK_WINDOW(window), FALSE);
+  gtk_window_set_focus_on_map(GTK_WINDOW(window), FALSE);
+
+  gtk_layer_init_for_window(GTK_WINDOW(window));
+  gtk_layer_set_anchor(GTK_WINDOW(window), GTK_LAYER_SHELL_EDGE_TOP, TRUE);
+  gtk_layer_set_anchor(GTK_WINDOW(window), GTK_LAYER_SHELL_EDGE_BOTTOM, TRUE);
+  gtk_layer_set_anchor(GTK_WINDOW(window), GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
+  gtk_layer_set_anchor(GTK_WINDOW(window), GTK_LAYER_SHELL_EDGE_RIGHT, TRUE);
+  gtk_layer_set_exclusive_zone(GTK_WINDOW(window), -1);
+  gtk_layer_set_keyboard_mode(GTK_WINDOW(window), GTK_LAYER_SHELL_KEYBOARD_MODE_NONE);
+  gtk_layer_set_layer(GTK_WINDOW(window), GTK_LAYER_SHELL_LAYER_OVERLAY);
+  gtk_layer_set_monitor(GTK_WINDOW(window), monitor);
+  gtk_layer_set_namespace(GTK_WINDOW(window), "battery-screen-border");
+
+  g_signal_connect(window, "draw", G_CALLBACK(draw_border), state);
+  g_signal_connect(window, "realize", G_CALLBACK(make_click_through), NULL);
+  gtk_widget_show(window);
+
+  return window;
+}
+
+static void rebuild_windows(BorderState *state) {
+  GdkDisplay *display = gdk_display_get_default();
+  const int monitor_count = gdk_display_get_n_monitors(display);
+
+  g_list_free_full(state->windows, (GDestroyNotify)gtk_widget_destroy);
+  state->windows = NULL;
+
+  for (int index = 0; index < monitor_count; ++index) {
+    state->windows = g_list_prepend(
+        state->windows, create_window(gdk_display_get_monitor(display, index), state)
+    );
+  }
+}
+
+static void monitors_changed(GdkDisplay *display, GdkMonitor *monitor, gpointer data) {
+  (void)display;
+  (void)monitor;
+  rebuild_windows(data);
+}
+
+static gboolean read_state(const char *path, BorderState *state) {
+  g_autofree char *contents = NULL;
+  g_autoptr(GError) error = NULL;
+  char from[16] = {0};
+  char to[16] = {0};
+
+  if (!g_file_get_contents(path, &contents, NULL, &error)) {
+    g_printerr("battery-screen-border: %s\n", error->message);
+    return FALSE;
+  }
+  if (sscanf(contents, "%d %15s %15s", &state->width, from, to) != 3
+      || state->width < 1 || state->width > 20 || !gdk_rgba_parse(&state->from, from)
+      || !gdk_rgba_parse(&state->to, to)) {
+    g_printerr("battery-screen-border: invalid state in %s\n", path);
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+int main(int argc, char **argv) {
+  BorderState state = {0};
+  GdkDisplay *display = NULL;
+
+  if (argc != 2 || !read_state(argv[1], &state)) {
+    return 2;
+  }
+
+  gtk_init(NULL, NULL);
+  display = gdk_display_get_default();
+  g_signal_connect(display, "monitor-added", G_CALLBACK(monitors_changed), &state);
+  g_signal_connect(display, "monitor-removed", G_CALLBACK(monitors_changed), &state);
+  rebuild_windows(&state);
+  gtk_main();
+  g_list_free_full(state.windows, (GDestroyNotify)gtk_widget_destroy);
+
+  return 0;
+}

--- a/scripts/desktop/update-battery-border-test.sh
+++ b/scripts/desktop/update-battery-border-test.sh
@@ -8,6 +8,9 @@ systemctl_log="$runtime_dir/systemctl.log"
 export SYSTEMCTL_LOG="$systemctl_log"
 trap 'rm -rf "$runtime_dir"' EXIT
 
+stop_cmd="--user stop battery-screen-border.service"
+restart_cmd="--user restart battery-screen-border.service"
+
 systemctl() {
   printf '%s\n' "$*" > "$SYSTEMCTL_LOG"
 }
@@ -27,20 +30,22 @@ check_case() {
     NOCTALIA_BATTERY_STATE="$state" \
     bash "$script_dir/update-battery-border.sh" "$threshold"
 
-  [ "$(< "$systemctl_log")" = "$expected_command" ]
-  if [ -n "$expected_border" ]; then
-    [ "$(< "$state_file")" = "$expected_border" ]
+  [[ -f "$systemctl_log" ]] || return 1
+  [[ "$(< "$systemctl_log")" = "$expected_command" ]] || return 1
+  if [[ -n "$expected_border" ]]; then
+    [[ -f "$state_file" ]] || return 1
+    [[ "$(< "$state_file")" = "$expected_border" ]] || return 1
   else
-    [ ! -e "$state_file" ]
+    [[ ! -e "$state_file" ]] || return 1
   fi
 }
 
-check_case 21 discharging "--user stop battery-screen-border.service"
-check_case 20 discharging "--user restart battery-screen-border.service" "3 #ffb000 #ffb000"
-check_case 15 discharging "--user restart battery-screen-border.service" "3 #ff7520 #ff7520"
-check_case 10 discharging "--user restart battery-screen-border.service" "3 #ff9500 #ff2d55"
-check_case 74 discharging "--user restart battery-screen-border.service" "3 #ff9110 #ff9110" 100
-check_case 12 charging "--user stop battery-screen-border.service"
+check_case 21 discharging "$stop_cmd"
+check_case 20 discharging "$restart_cmd" "3 #ffb000 #ffb000"
+check_case 15 discharging "$restart_cmd" "3 #ff7520 #ff7520"
+check_case 10 discharging "$restart_cmd" "3 #ff9500 #ff2d55"
+check_case 74 discharging "$restart_cmd" "3 #ff9110 #ff9110" 100
+check_case 12 charging "$stop_cmd"
 
 if XDG_RUNTIME_DIR="$runtime_dir" bash "$script_dir/update-battery-border.sh" 11 2>/dev/null; then
   exit 1

--- a/scripts/desktop/update-battery-border-test.sh
+++ b/scripts/desktop/update-battery-border-test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -eu
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+runtime_dir="$(mktemp -d)"
+state_file="$runtime_dir/battery-screen-border"
+systemctl_log="$runtime_dir/systemctl.log"
+export SYSTEMCTL_LOG="$systemctl_log"
+trap 'rm -rf "$runtime_dir"' EXIT
+
+systemctl() {
+  printf '%s\n' "$*" > "$SYSTEMCTL_LOG"
+}
+export -f systemctl
+
+check_case() {
+  local percent="$1"
+  local state="$2"
+  local expected_command="$3"
+  local expected_border="${4:-}"
+  local threshold="${5:-20}"
+
+  rm -f "$state_file" "$systemctl_log"
+  printf 'stale\n' > "$state_file"
+  XDG_RUNTIME_DIR="$runtime_dir" \
+    NOCTALIA_BATTERY_PERCENT="$percent" \
+    NOCTALIA_BATTERY_STATE="$state" \
+    bash "$script_dir/update-battery-border.sh" "$threshold"
+
+  [ "$(< "$systemctl_log")" = "$expected_command" ]
+  if [ -n "$expected_border" ]; then
+    [ "$(< "$state_file")" = "$expected_border" ]
+  else
+    [ ! -e "$state_file" ]
+  fi
+}
+
+check_case 21 discharging "--user stop battery-screen-border.service"
+check_case 20 discharging "--user restart battery-screen-border.service" "3 #ffb000 #ffb000"
+check_case 15 discharging "--user restart battery-screen-border.service" "3 #ff7520 #ff7520"
+check_case 10 discharging "--user restart battery-screen-border.service" "3 #ff9500 #ff2d55"
+check_case 74 discharging "--user restart battery-screen-border.service" "3 #ff9110 #ff9110" 100
+check_case 12 charging "--user stop battery-screen-border.service"
+
+if XDG_RUNTIME_DIR="$runtime_dir" bash "$script_dir/update-battery-border.sh" 11 2>/dev/null; then
+  exit 1
+fi
+
+printf 'update-battery-border: ok\n'

--- a/scripts/desktop/update-battery-border.sh
+++ b/scripts/desktop/update-battery-border.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 set -eu
 
-override_file="$HOME/.local/state/niri/battery-border.kdl"
+state_file="${XDG_RUNTIME_DIR:?}/battery-screen-border"
+service_name="battery-screen-border.service"
+warning_threshold="${1:-}"
+
+if ! [[ "$warning_threshold" =~ ^[0-9]+$ ]] || [ "$warning_threshold" -lt 12 ] || [ "$warning_threshold" -gt 100 ]; then
+  printf 'warning threshold must be an integer between 12 and 100\n' >&2
+  exit 2
+fi
+warning_threshold=$((10#$warning_threshold))
 
 read_battery() {
   local battery=""
@@ -23,56 +31,40 @@ read_battery() {
   battery_state="unknown"
 }
 
-write_override() {
-  local directory="${override_file%/*}"
+write_state() {
   local temporary=""
 
-  mkdir -p "$directory"
-  temporary="$(mktemp "$override_file.XXXXXX")"
+  temporary="$(mktemp "$state_file.XXXXXX")"
   trap 'rm -f "$temporary"' EXIT
   cat > "$temporary"
-  mv "$temporary" "$override_file"
+  mv "$temporary" "$state_file"
   trap - EXIT
 }
 
-render_alarm() {
-  local progress=$((20 - percent))
-  local active_green=$((176 - (107 * progress / 9)))
-  local active_blue=$((0 + (58 * progress / 9)))
-  local inactive_red=$((107 + (15 * progress / 9)))
-  local inactive_green=$((75 - (44 * progress / 9)))
-  local inactive_blue=$((0 + (26 * progress / 9)))
-  local active=""
-  local inactive=""
+render_color() {
+  local progress=$((warning_threshold - percent))
+  local range=$((warning_threshold - 11))
+  local green=$((176 - (107 * progress / range)))
+  local blue=$((58 * progress / range))
 
-  printf -v active '#ff%02x%02x' "$active_green" "$active_blue"
-  printf -v inactive '#%02x%02x%02x' "$inactive_red" "$inactive_green" "$inactive_blue"
-
-  cat <<EOF
-layout {
-    border {
-        active-color "$active"
-        inactive-color "$inactive"
-    }
-}
-EOF
+  printf '#ff%02x%02x' "$green" "$blue"
 }
 
 read_battery
 battery_state="${battery_state,,}"
 battery_state="${battery_state// /_}"
+if [[ "$percent" =~ ^[0-9]+$ ]]; then
+  percent=$((10#$percent))
+fi
 
-if ! [[ "$percent" =~ ^[0-9]+$ ]] || [ "$percent" -gt 20 ] || [[ "$battery_state" != "discharging" && "$battery_state" != "pending_discharge" ]]; then
-  printf '// Low-battery border inactive.\n' | write_override
+if ! [[ "$percent" =~ ^[0-9]+$ ]] || [ "$percent" -gt "$warning_threshold" ] || [[ "$battery_state" != "discharging" && "$battery_state" != "pending_discharge" ]]; then
+  rm -f "$state_file"
+  systemctl --user stop "$service_name" || true
 elif [ "$percent" -le 10 ]; then
-  cat <<'EOF' | write_override
-layout {
-    border {
-        active-gradient from="#ff9500" to="#ff2d55" angle=90 relative-to="workspace-view"
-        inactive-gradient from="#7a1f1a" to="#4a0b12" angle=90 relative-to="workspace-view"
-    }
-}
-EOF
+  printf '3 #ff9500 #ff2d55\n' | write_state
+  systemctl --user restart "$service_name"
 else
-  render_alarm | write_override
+  color="$(render_color)"
+  printf '3 %s %s\n' "$color" "$color" | write_state
+  systemctl --user restart "$service_name"
 fi


### PR DESCRIPTION
## Summary

- replace Niri's per-window low-battery border override with a click-through screen-edge overlay
- show a 3px amber-to-red frame on every connected output while discharging below the configured threshold
- keep the Noctalia battery warning threshold configurable and clear the overlay while charging
- handle monitor hotplug through a hook-controlled systemd user service

## Why

The previous implementation only recolored borders around managed windows, so it was easy to miss and disappeared with fullscreen windows. The overlay uses the compositor's overlay layer and an empty input region, making the warning visible around the whole screen without stealing pointer or keyboard input.

## Validation

- battery hook self-test, including the 100% threshold scenario
- repository formatting and pre-commit hooks
- Home Manager activation builds for `jsg@amd` and `jga@yoga`
- generated Noctalia and Niri config validation
- generated systemd unit verification
- live Niri layer smoke test on `eDP-1`