### PR TITLE
fix(shell): make bat manpager session-wide

### DIFF
--- a/home/modules/dotfiles.nix
+++ b/home/modules/dotfiles.nix
@@ -57,7 +57,8 @@
 
         sessionPath = [ "$HOME/.local/bin" ];
         sessionVariables = {
-          MANPAGER = "${pkgs.bat}/bin/bat -l man -p'";
+          MANPAGER = "${pkgs.coreutils}/bin/env BATMAN_IS_BEING_MANPAGER=yes ${pkgs.bat-extras.batman}/bin/batman";
+          MANROFFOPT = "-c";
           NIX_BUILD_CORES = "$(${pkgs.busybox}/bin/nproc --ignore=1)";
           PAGER = "${pkgs.bat}/bin/bat -p";
           SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";

--- a/home/modules/programs.nix
+++ b/home/modules/programs.nix
@@ -230,7 +230,6 @@ in
             fi
             ${builtins.readFile ../../scripts/shell/secret-export.sh}
 
-            eval "$(batman --export-env)"
             eval "$(command up --init bash)"
             source <(command git-worktree-cd --init bash)
           '';


### PR DESCRIPTION
## Summary

- use the installed `batman` wrapper for the session-wide `MANPAGER`
- set the required `MANROFFOPT=-c` for every session
- remove the redundant Bash-only pager override

## Root cause

The shared `MANPAGER` ended in a stray apostrophe, so `man` parsed `bat -p'` as `bat -p047` and exited with an invalid-option error. Interactive Bash masked this by replacing the value through `batman --export-env`; shells and sessions that skipped that startup path inherited the malformed command.

## Impact

Manpages continue to use Bat, but now work consistently in non-Bash, profile-only, and `TERM=dumb` setups as well as normal interactive Bash sessions.

## Validation

- exercised `man true` in an isolated pseudo-terminal using the evaluated Home Manager variables
- evaluated `MANPAGER` and `MANROFFOPT` for all four Home Manager configurations
- built the `jsg@amd` and `jga@yoga` activation packages
- passed repository hooks for both changed files and all commit/push hooks

The all-files hook run also found an unrelated existing executable-bit failure in `scripts/desktop/update-battery-border-test.sh`; this PR does not touch that file.