### PR TITLE
fix(kernel): pin back to 7.1 and watch for evdi 7.2 support

### DIFF
--- a/.github/workflows/evdi-watch.yml
+++ b/.github/workflows/evdi-watch.yml
@@ -7,6 +7,7 @@ on:
 concurrency:
   group: evdi-watch
   cancel-in-progress: false
+  queue: max
 permissions: {}
 jobs:
   check:

--- a/.github/workflows/evdi-watch.yml
+++ b/.github/workflows/evdi-watch.yml
@@ -14,6 +14,9 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          # keep the write token out of the steps that evaluate upstream nix
+          persist-credentials: false
       - uses: cachix/install-nix-action@6004951b182f8860210c8d6f0d808ec5b1a33d28  # v25
       - id: evdi
         continue-on-error: true
@@ -30,5 +33,5 @@ jobs:
           git checkout -b evdi-kernel-7-2
           git rm -q .github/workflows/evdi-watch.yml
           git commit -aqm 'feat(kernel): back to 7.2, evdi builds again'
-          git push -qf origin evdi-kernel-7-2
+          git push -qf "https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY" evdi-kernel-7-2
           gh pr create --fill --head evdi-kernel-7-2 || true

--- a/.github/workflows/evdi-watch.yml
+++ b/.github/workflows/evdi-watch.yml
@@ -2,29 +2,32 @@
 name: evdi 7.2 watch
 on:
   schedule:
-    - cron: '17 4 * * 1'
+    - cron: 17 4 * * 1
   workflow_dispatch:
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      # push the promotion branch and open its PR
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v25
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+      - uses: cachix/install-nix-action@6004951b182f8860210c8d6f0d808ec5b1a33d28  # v25
       - id: evdi
         continue-on-error: true
-        run: nix build --no-link 'github:NixOS/nixpkgs/nixos-unstable#linuxKernel.packages.linux_7_2.evdi'
+        run: |
+          nix flake update nixpkgs
+          sed -i 's/packages\.linux_7_1/packages.linux_7_2/' nixos/common.nix
+          nix build --no-link '.#nixosConfigurations.amd.config.boot.kernelPackages.evdi'
       - if: steps.evdi.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
+        run: |-
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git checkout -b evdi-kernel-7-2
-          nix flake update nixpkgs
-          sed -i 's/packages\.linux_7_1/packages.linux_7_2/' nixos/common.nix
           git rm -q .github/workflows/evdi-watch.yml
           git commit -aqm 'feat(kernel): back to 7.2, evdi builds again'
           git push -qf origin evdi-kernel-7-2

--- a/.github/workflows/evdi-watch.yml
+++ b/.github/workflows/evdi-watch.yml
@@ -1,0 +1,31 @@
+---
+name: evdi 7.2 watch
+on:
+  schedule:
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+      - id: evdi
+        continue-on-error: true
+        run: nix build --no-link 'github:NixOS/nixpkgs/nixos-unstable#linuxKernel.packages.linux_7_2.evdi'
+      - if: steps.evdi.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout -b evdi-kernel-7-2
+          nix flake update nixpkgs
+          sed -i 's/packages\.linux_7_1/packages.linux_7_2/' nixos/common.nix
+          git rm -q .github/workflows/evdi-watch.yml
+          git commit -aqm 'feat(kernel): back to 7.2, evdi builds again'
+          git push -qf origin evdi-kernel-7-2
+          gh pr create --fill --head evdi-kernel-7-2 || true

--- a/.github/workflows/evdi-watch.yml
+++ b/.github/workflows/evdi-watch.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: 17 4 * * 1
   workflow_dispatch:
+concurrency:
+  group: evdi-watch
+  cancel-in-progress: false
 permissions: {}
 jobs:
   check:
@@ -15,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
+          # manual runs must branch off the default branch, not the selected ref
+          ref: ${{ github.event.repository.default_branch }}
           # keep the write token out of the steps that evaluate upstream nix
           persist-credentials: false
       - uses: cachix/install-nix-action@6004951b182f8860210c8d6f0d808ec5b1a33d28  # v25
@@ -34,4 +39,5 @@ jobs:
           git rm -q .github/workflows/evdi-watch.yml
           git commit -aqm 'feat(kernel): back to 7.2, evdi builds again'
           git push -qf "https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY" evdi-kernel-7-2
-          gh pr create --fill --head evdi-kernel-7-2 || true
+          gh pr view evdi-kernel-7-2 --json state -q .state | grep -qx OPEN ||
+            gh pr create --fill --head evdi-kernel-7-2

--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -189,7 +189,7 @@
     initrd.kernelModules = [ "evdi" ];
     loader.systemd-boot.enable = true;
     loader.efi.canTouchEfiVariables = true;
-    kernelPackages = pkgs.linuxKernel.packages.linux_7_2;
+    kernelPackages = pkgs.linuxKernel.packages.linux_7_1;
     kernelModules = [ ];
     kernelParams = [
       "acpi_backlight=native"


### PR DESCRIPTION
Reverts the kernel bump in bd8a348 and automates the return trip.

## The failure

`nixos/common.nix` pulls `config.boot.kernelPackages.evdi` into `boot.extraModulePackages` for DisplayLink, so bumping to `linux_7_2` forces an out-of-tree rebuild of evdi 1.14.15. It fails, taking `linux-7.2-modules` and the whole `nixos-system-amd` closure with it.

The 25 lines in the build error are all `note:` breadcrumbs from a `get_task_comm`/`strscpy_pad` macro expansion in `evdi_gem.c` — a red herring. The real errors are in `evdi_modeset.c`:

```
evdi_modeset.c:76        drm_atomic_get_new_crtc_state — incompatible pointer type
evdi_modeset.c:183       void (*)(struct drm_crtc *, struct drm_atomic_commit *)
                    from void (*)(struct drm_crtc *, struct drm_atomic_state *)
evdi_modeset.c:229, 327  drm_atomic_get_old_plane_state — same
evdi_modeset.c:393, 402  same, on the plane helpers
```

Kernel 7.2 replaced `struct drm_atomic_state *` with `struct drm_atomic_commit *` across the DRM atomic helper callbacks and accessors. evdi 1.14.15 — the only version in nixpkgs — predates it. The package sets `env.CFLAGS = "-Wno-error"`, but the kernel build appends `-Werror=incompatible-pointer-types`, so it stays fatal. Not fixable here short of carrying an evdi patch set.

`linux_7_1` is alive in the pinned nixpkgs at 7.1.9; `linux_7_0` and `linux_6_19` are already `throw`n as EOL.

## The watcher

`.github/workflows/evdi-watch.yml` builds evdi against `nixos-unstable`'s 7.2 every Monday. Three deliberate choices:

- **`continue-on-error` on the step, not the job.** Otherwise a failed-workflow email arrives every Monday for however many months evdi lags, gets muted, and the one that matters is missed. Green and silent while broken; a PR appearing is the only signal.
- **`nix flake update nixpkgs` is not optional.** The check queries fresh `nixos-unstable`; the build uses `flake.lock`. Flipping `common.nix` without bumping the lock reintroduces the exact failure.
- **Self-deletion lives in the PR.** `git rm` of the workflow is part of the same diff that flips the kernel, so merging uninstalls the schedule. No cleanup API, no state to track.

## Before this works

Settings → Actions → General → Workflow permissions → **"Allow GitHub Actions to create and approve pull requests"**. Off by default. Without it `gh pr create` fails, `|| true` swallows it, and you get a pushed branch with no PR and no notice.

## Verified

- `nix build .#nixosConfigurations."amd".config.system.build.toplevel` — exit 0, full closure, nothing kernel-related left to build.
- `nix fmt` — `yamlfix`, `check-yaml`, `check-github-workflows`, `betterleaks`, `nixfmt`, `statix` all pass. (`shellcheck` fails on `dotfiles/blesh/init.sh`, pre-existing on main, untouched here.)
- The watcher's success path has **not** been exercised — it cannot run until evdi actually supports 7.2. To dry-run it, temporarily point the check at `linuxKernel.packages.linux_6_12.evdi` and `gh workflow run evdi-watch.yml`.

## Unrelated, but noticed

`flake.lock` on `main` is missing entries for inputs added in c44367d — every nix command in a clean checkout dirties the tree by adding them. Left alone here to keep this diff to two files.