### PR TITLE
fix(emacs): make Nix tree-sitter grammars reach the Emacs daemon

### DIFF
--- a/dotfiles/emacs/config.org
+++ b/dotfiles/emacs/config.org
@@ -123,10 +123,6 @@ state.
           (lambda ()
             (setq file-name-handler-alist me/-file-name-handler-alist)))
 #+END_SRC
-** Disable =site-run-file=
-#+BEGIN_SRC emacs-lisp
-(setq site-run-file nil)
-#+END_SRC
 ** Don't compact font caches
 #+BEGIN_SRC emacs-lisp
 (setq inhibit-compacting-font-caches t)

--- a/dotfiles/emacs/config.org
+++ b/dotfiles/emacs/config.org
@@ -46,33 +46,6 @@ The config is divided into sensible sections (hopefully) to segregate mode-speci
 #+END_SRC
 ** Early init
 Early startup settings live in =~/.emacs.d/early-init.el= so they are applied before package and frame initialization. Keeping them in this file was too late for package startup and would also make tangling try to rewrite Home Manager's symlinked early-init file.
-** Straight
-Straight is a package manager for Emacs making it easier to fetch packages from anywhere.
-
-We want it to integrate nicely with use-package
-#+BEGIN_SRC emacs-lisp
-(setq straight-cache-autoloads t
-      straight-check-for-modifications '(check-on-save)
-      straight-vc-git-auto-fast-forward nil
-      straight-vc-git-default-clone-depth 1
-      straight-vc-git-default-protocol 'https
-      use-package-compute-statistics nil
-      vc-follow-symlinks t
-      straight-use-package-by-default t
-      )
-#+END_SRC
-** Defer Compilations
-
-#+BEGIN_SRC emacs-lisp
-(setq native-comp-deferred-compilation t)
-#+END_SRC
-** Low-hanging Speedup Fruits
-Resizing the Emacs frame can be a terribly expensive part of changing the font. By inhibiting this,
-we easily halve startup times with fonts that are larger than the system default.
-
-#+BEGIN_SRC emacs-lisp
-(setq frame-inhibit-implied-resize t)
-#+END_SRC
 ** Deferred startup helpers
 #+BEGIN_SRC emacs-lisp
 (defun me/run-after-startup-idle (seconds function)
@@ -82,52 +55,6 @@ we easily halve startup times with fonts that are larger than the system default
                   (list 'run-with-idle-timer seconds nil
                         (list 'quote function)))))
 #+END_SRC
-** Reduce GC
-Following [[https://github.com/hlissner/doom-emacs/blob/develop/docs/faq.org#how-does-doom-start-up-so-quickly][Doom-Emacs FAQ]], we max the garbage collection threshold on startup, and reset it to the original value after.
-
-#+BEGIN_SRC emacs-lisp
-;; max memory available for gc on startup
-(defvar me/gc-cons-threshold 16777216)
-
-(setq gc-cons-threshold most-positive-fixnum
-      gc-cons-percentage 0.6)
-
-(add-hook 'emacs-startup-hook
-          (lambda ()
-            (setq gc-cons-threshold me/gc-cons-threshold
-                  gc-cons-percentage 0.1)))
-
-;; max memory available for gc when opening minibuffer
-(defun me/defer-garbage-collection-h ()
-  (setq gc-cons-threshold most-positive-fixnum))
-
-(defun me/restore-garbage-collection-h ()
-  ;; Defer it so that commands launched immediately after will enjoy the
-  ;; benefits.
-  (run-at-time
-   1 nil (lambda () (setq gc-cons-threshold me/gc-cons-threshold))))
-
-(add-hook 'minibuffer-setup-hook #'me/defer-garbage-collection-h)
-(add-hook 'minibuffer-exit-hook #'me/restore-garbage-collection-h)
-(setq garbage-collection-messages t)
-#+END_SRC
-** Temporarily avoid special handling of files
-
-This script temporarily disables file name handlers during the startup of Emacs to speed up the
-process. Once Emacs has finished starting up, it restores the file name handlers to their original
-state.
-#+BEGIN_SRC emacs-lisp
-(defvar me/-file-name-handler-alist file-name-handler-alist)
-(setq file-name-handler-alist nil)
-(add-hook 'emacs-startup-hook
-          (lambda ()
-            (setq file-name-handler-alist me/-file-name-handler-alist)))
-#+END_SRC
-** Don't compact font caches
-#+BEGIN_SRC emacs-lisp
-(setq inhibit-compacting-font-caches t)
-#+END_SRC
-
 ** Use the garbage collector magic hack
 #+BEGIN_SRC emacs-lisp
 (use-package gcmh
@@ -253,13 +180,6 @@ Emacs is very conservative about assuming encoding. Everything is UTF-8 these da
   (interactive)
   (ansi-color-apply-on-region (point-min) (point-max)))
 
-#+END_SRC
-** Extra Garbage Collection (disabled)
-#+BEGIN_SRC emacs-lisp
-;; (add-function :after after-focus-change-function
-;;               (defun me/garbage-collect-maybe ()
-;;                 (unless (frame-focus-state)
-;;                   (garbage-collect))))
 #+END_SRC
 ** non-ASCII characters
 #+BEGIN_SRC emacs-lisp
@@ -389,9 +309,6 @@ Corfu is a small CAPF UI. Eglot publishes LSP completions through CAPF, so the e
   :init
   (when (boundp 'treesit-enabled-modes)
     (setq treesit-enabled-modes t))
-  (when (boundp 'treesit-auto-install-grammar)
-    ;; Grammars are provided by Nix; ask before compiling/downloading any gap.
-    (setq treesit-auto-install-grammar 'ask))
   (when (boundp 'completion-eager-update)
     (setq completion-eager-update t))
   (when (boundp 'completion-eager-display)
@@ -1025,7 +942,6 @@ Eglot replaces the lsp-mode stack and uses native Emacs interfaces: CAPF for Cor
    (toml-mode . eglot-ensure)
    (typst-mode . eglot-ensure)
    (typescript-mode . eglot-ensure)
-   (yaml-mode . eglot-ensure)
    (yaml-ts-mode . eglot-ensure))
   :bind
   (:map eglot-mode-map
@@ -1863,16 +1779,6 @@ simple package that enable titlecasing
   :bind ("C-c w t" . why-this)
   :config ())
 #+end_src
-*** YAML mode
-#+BEGIN_SRC emacs-lisp
-(use-package yaml-mode
-  :defer t
-  :init
-  (when (fboundp 'yaml-ts-mode)
-    (add-to-list 'major-mode-remap-alist '(yaml-mode . yaml-ts-mode)))
-  :mode
-  ("\\.ya?ml\\'" . yaml-mode))
-#+END_SRC
 *** Yasnippet
 Yasnippet is one of the main reasons I have a hard time moving away. The ease of creating new
 snippets for common operations instead of macros, allows it to be portable and powerful.

--- a/dotfiles/emacs/config.org
+++ b/dotfiles/emacs/config.org
@@ -983,7 +983,7 @@ Eglot replaces the lsp-mode stack and uses native Emacs interfaces: CAPF for Cor
                    (:diagnostics (:enable :json-false)
                     :codeAction (:nameExtractFunction "extracted_function"
                                  :nameExtractVariable "extracted_variable"))))))
-           )
+           ))
     (add-to-list 'eglot-server-programs server))
   (add-to-list 'eglot-server-programs
                '((yaml-mode yaml-ts-mode) . ("yaml-language-server" "--stdio")))

--- a/dotfiles/emacs/early-init.el
+++ b/dotfiles/emacs/early-init.el
@@ -7,7 +7,6 @@
 
 (setq package-enable-at-startup nil
       native-comp-async-report-warnings-errors nil
-      site-run-file nil
       frame-inhibit-implied-resize t
       inhibit-compacting-font-caches t)
 

--- a/dotfiles/emacs/init.el
+++ b/dotfiles/emacs/init.el
@@ -72,7 +72,12 @@
 ((file-readable-p me/config-org-file)
   (require 'org)
   (require 'ob-tangle)
-  (org-babel-load-file me/config-org-file))
+  ;; Not `org-babel-load-file': its own staleness check uses
+  ;; `file-newer-than-file-p', which follows the home-manager symlink to a
+  ;; store file with an epoch mtime and so never re-tangles.
+  (org-babel-tangle-file me/config-org-file me/config-el-file
+                         (rx string-start (or "emacs-lisp" "elisp") string-end))
+  (load-file me/config-el-file))
  (t
   (user-error "Cannot find readable Emacs config: %s or %s"
               me/config-el-file

--- a/flake.lock
+++ b/flake.lock
@@ -65,6 +65,22 @@
         "type": "github"
       }
     },
+    "cursor-plugins-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787281804,
+        "narHash": "sha256-rTkT/2dliMzvwDkza2+JNhSIzcTr9fXjvK2zwi/lRl8=",
+        "owner": "cursor",
+        "repo": "plugins",
+        "rev": "46125561306434d8a1d7745d540d8932ab0cd2a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cursor",
+        "repo": "plugins",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -266,6 +282,22 @@
       "original": {
         "owner": "nix-community",
         "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "mattpocock-skills-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787309793,
+        "narHash": "sha256-FPAAotNqA5aHrFDlj/XddoLs4TDKi+4J5H/mvevlOlk=",
+        "owner": "mattpocock",
+        "repo": "skills",
+        "rev": "5b15a47f2d7150f545fbcacbfe381787fc0230dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mattpocock",
+        "repo": "skills",
         "type": "github"
       }
     },
@@ -558,10 +590,12 @@
       "inputs": {
         "agent-browser-src": "agent-browser-src",
         "claude-code-src": "claude-code-src",
+        "cursor-plugins-src": "cursor-plugins-src",
         "flake-utils": "flake-utils",
         "git-hooks": "git-hooks",
         "hermes-agent": "hermes-agent",
         "home-manager": "home-manager",
+        "mattpocock-skills-src": "mattpocock-skills-src",
         "navi-cheats-src": "navi-cheats-src",
         "navi-tldr-pages-src": "navi-tldr-pages-src",
         "nix-index-database": "nix-index-database",

--- a/home/modules/default.nix
+++ b/home/modules/default.nix
@@ -2,6 +2,7 @@
 
 {
   imports = [
+    inputs.noctalia.homeModules.default
     inputs.waytorandr.homeManagerModules.default
     ./dotfiles.nix
     ./packages.nix

--- a/home/modules/services.nix
+++ b/home/modules/services.nix
@@ -167,7 +167,6 @@ in
       cfg = config.customServices;
       coreServices = {
         emacs = {
-          package = pkgs.emacs31-pgtk;
           startWithUserSession = false;
           enable = true;
           defaultEditor = true;

--- a/home/systems/seeq.nix
+++ b/home/systems/seeq.nix
@@ -125,7 +125,6 @@ in
 
   services.emacs = {
     enable = lib.mkForce true;
-    package = lib.mkForce pkgs.emacs-nox;
     startWithUserSession = lib.mkForce true;
     socketActivation.enable = lib.mkForce false;
     defaultEditor = lib.mkForce false;

--- a/home/systems/seeq.nix
+++ b/home/systems/seeq.nix
@@ -120,7 +120,7 @@ in
       enable = true;
     };
 
-    emacs.package = lib.mkForce pkgs.emacs-nox;
+    emacs.package = lib.mkForce pkgs.emacs31-nox;
   };
 
   services.emacs = {


### PR DESCRIPTION
## Problem

Opening a YAML file fails with:

```
Error encountered when installing language grammar: (file-missing Searching for program No such file or directory cc)
```

`home/modules/programs.nix:254` already ships every grammar via `treesit-grammars.with-all-grammars`. Emacs only falls back to `treesit-install-language-grammar` (which shells out to `cc`) when it can't *see* them.

## Root cause — the daemon ran the unwrapped Emacs

`services.emacs.package` defaults to `programs.emacs.finalPackage`, the `emacsWithPackages` wrapper (home-manager `modules/services/emacs.nix:58`). Two call sites overrode it with a raw package:

- `home/modules/services.nix:170` — `package = pkgs.emacs31-pgtk;`
- `home/systems/seeq.nix:128` — `package = lib.mkForce pkgs.emacs-nox;`

Both were shadowing the wrapper with a bare package. The *choice* of build in each is correct (see below); the override site was not.

The wrapper is the only thing that puts `emacs-packages-deps/share/emacs/site-lisp` on `EMACSLOADPATH`, and that `site-start.el` is the only file in the closure carrying the `(add-to-list 'treesit-extra-load-path ...)` line. So the daemon had no grammars at all. `emacsclient` is the primary entry point here (the `ec` alias, `core.editor`, `EDITOR`/`VISUAL` on seeq), so this is the path that failed.

Before / after, evaluated from the flake:

```
ExecStart (running unit) = .../emacs-pgtk-31.1-rc1/bin/emacs --fg-daemon              # unwrapped
ExecStart (this branch)  = .../emacs-pgtk-with-packages-31.0.91/bin/emacs --fg-daemon # wrapper
```

### The package choices are deliberate and are preserved

Dropping `services.emacs.package` is not "fall back to whatever nixpkgs ships". `services.emacs.package` defaults to `programs.emacs.finalPackage`, which wraps `programs.emacs.package` — so the explicit choices simply move up one level to where they were already declared, and now the wrapper applies to them:

| | `programs.emacs.package` | daemon after this branch |
|---|---|---|
| every graphical host | `pkgs.emacs31-pgtk` (`home/modules/programs.nix:251`) | `emacs-pgtk-with-packages-31.0.91` |
| seeq | `lib.mkForce pkgs.emacs31-nox` (`home/systems/seeq.nix:123`) | `emacs-nox-with-packages-31.0.91` |

Emacs **31** is intentional — nixpkgs' `pkgs.emacs` still defaults to 30. **nox** on seeq is intentional — that box is used headless over ssh, so a GUI toolkit build is dead weight. Neither is touched by this PR beyond making the daemon honour them.

## Also fixed

**seeq was two hosts stuck on Emacs 30.** `programs.emacs.package` there was `pkgs.emacs-nox` — the nixpkgs default, i.e. 30.2 — while every other host pins `emacs31-pgtk`. Correct build, wrong version, and invisible because the old `services.emacs.package` override said `emacs-nox` too. Now `pkgs.emacs31-nox`: still headless, no longer a major version behind.

**`config.org` changes never reached Emacs.** `org-babel-load-file`'s staleness check uses `file-newer-than-file-p`, which *follows* symlinks; `~/.emacs.d/config.org` is a home-manager store symlink resolving to an epoch mtime, so it never re-tangled:

```
file-newer-than(config.org, config.el) => nil
  lstat(symlink)   2026-08-24 09:54   <- what init.el checks
  truename (store) 1970-01-01 01:00   <- what org checks
  config.el        2026-08-06 15:35   <- what actually loaded
```

Every `config.org` change since 2026-08-06 was inert. `init.el` now tangles explicitly. Self-heals; no manual `rm` needed.

**The flake did not evaluate.** `cb94eb5` added `package = inputs.noctalia.packages.${system}.default` but removed `inputs.noctalia.homeModules.default` from the imports in the same commit — and that module is what *defines* the option. Every host failed with `The option 'programs.noctalia' does not exist`, blocking `home-manager switch` everywhere. Import restored, plus `nix flake lock` to add `cursor-plugins-src` and `mattpocock-skills-src`, which `flake.nix` declared but `flake.lock` lacked.

**Duplicated and dead startup config removed** (`config.org`, 94 lines). Duplicates of `init.el`/`early-init.el` which run first and win (`** Straight` — `init.el`'s own comment says config.org is too late; `** Low-hanging Speedup Fruits`; `** Don't compact font caches`; `** Temporarily avoid special handling of files`, which captured `nil` and "restored" `nil`). Dead code (`native-comp-deferred-compilation`, an obsolete alias since 29.1 already defaulting to `t`; a fully commented-out GC section; `treesit-auto-install-grammar`, whose `boundp` guard is `nil` at config-load time so the setq never fired). And `** Reduce GC`, whose minibuffer hooks stomp `gc-cons-threshold` back to 16MB, fighting the `gcmh` package enabled a few blocks below — gcmh kept, hand-rolled version dropped.

**`site-run-file` overrides removed** — cleanup, *not* a fix. My first attempt at this PR claimed these were the root cause. That was wrong. Emacs 31 loads `site-start.el` **before** `early-init.el` (`startup.el:1523-1527`: *"This used to come after the early init file, but was moved here"*), so the setq landed and changed nothing:

```
PROBE-EARLY: site-run-file="site-start" extra=(".../emacs-packages-deps/lib/")
PROBE-INIT:  site-run-file=nil          extra=(".../emacs-packages-deps/lib/") yaml=t
```

**`config.org` did not parse at all.** `config.org:986` was one `)` short: the `dolist` in `use-package eglot` absorbed the rest of the form, and the tangled `config.el` hit end-of-file mid-read. `load-file` aborts the whole file on a read error, so **every form after the eglot block never evaluated** — eglot, dape, YAML, and the rest of the file:

```
Error: end-of-file (#<buffer  *load*>)
  load-with-code-conversion("~/.emacs.d/config.el" ...)
last balanced top-level form ends at line 646 of 1314
```

Pre-existing on `main` since `f1c25dc` (2026-08-12) — the same day the running daemon was started, which is why it spent 13 days on a half-loaded config. Unrelated to the treesit work, but it masked the result: with the eglot block dead, none of the YAML wiring this PR reasons about was ever live.

**`*** YAML mode` block removed.** Emacs 31 ships `("\\.ya?ml\\'" . yaml-ts-mode-maybe)` in `auto-mode-alist`, and `yaml-ts-mode.el` already registers `(yaml-mode . yaml-ts-mode)` in `treesit-major-mode-remap-alist`. The block shadowed both.

Deliberately **not** adding `gcc`/`stdenv.cc` — the point of `with-all-grammars` is that nothing compiles at runtime. Checked every core `*-ts-mode` language against the Nix grammar set: none is missing, so there is no gap to guard. (`terraform` came up in review as a suspected gap; Emacs 31 ships no terraform mode at all and `.tf` has no `auto-mode-alist` entry, so it cannot trigger this.)

## Commits

| | |
|---|---|
| `b9a1f2b` | the actual fix — daemon uses `finalPackage` |
| `059c851` | re-tangle `config.org` when the symlink changes |
| `7377fc5` | drop inert `site-run-file` overrides |
| `28a19a1` | restore noctalia module import, lock missing inputs |
| `d4f50ee` | drop duplicated and dead startup config |
| `64b9ada` | close the eglot `dolist` binding list |
| `6a1244f` | pin seeq to `emacs31-nox` |

## Verification

Run and confirmed:

- all five `homeConfigurations` evaluate (they did not before `28a19a1`) and every one resolves `services.emacs.package` to a `-with-packages-` wrapper of the intended build:

```
jsg@SEEQWS-001     emacs-nox-with-packages-31.0.91
jsg@SEEQWS-002     emacs-nox-with-packages-31.0.91
jga@yoga           emacs-pgtk-with-packages-31.0.91
jsg@amd            emacs-pgtk-with-packages-31.0.91
pi@raspberrypi     emacs-pgtk-with-packages-31.0.91
```
- the evaluated daemon package yields `treesit-extra-load-path` = `(".../emacs-packages-deps/lib/")` and `(treesit-language-available-p 'yaml)` = `t`; the unwrapped binary yields `nil`/`nil`
- the generated `ExecStart` is now the wrapper path
- `site-start.el` is the only file in the deps closure adding to `treesit-extra-load-path`; site-start runs before early-init (probe above)
- `config.org` tangles clean after the cuts — 125 blocks → 117; all removals absent from the tangled output and `treesit-enabled-modes` / `gcmh-mode` / `me/run-after-startup-idle` / `yaml-language-server` all still present

  Correcting an earlier claim in this description: the "113 readable top-level forms, no read errors" line was wrong. That probe read forms sequentially and treated the `end-of-file` it hit as the end of the file rather than as a failure, so it reported success on a file Emacs refuses to load. Replaced with `check-parens` over the tangled output, which fails loudly.
- with the paren fixed, the **real** config loads end to end (straight packages built, not `-Q`) and opening a `.yml` gives:

```
MODE=yaml-ts-mode
treesit-available=t  yaml-grammar=t
auto-mode "x.yml" -> yaml-ts-mode-maybe
parsers: (#<treesit-parser for yaml>)
faces:   f/o/o -> font-lock-property-use-face, bar -> font-lock-string-face, 1 -> font-lock-number-face
eglot:   ((yaml-mode yaml-ts-mode) "yaml-language-server" "--stdio"), binary on PATH, eglot-ensure in yaml-ts-mode-hook
```

- `nixfmt --check` clean, `statix` clean on all three changed `.nix` files

Remaining on the machine itself:

```bash
home-manager switch --flake .
systemctl --user cat emacs | grep ExecStart      # expect the -with-packages- path
emacsclient -e 'treesit-extra-load-path'
emacsclient -e "(treesit-language-available-p 'yaml)"
```

The seeq (`emacs31-nox`) path is verified by evaluation only — its wrapper derivation isn't built locally. Same mechanism, different host.

## Not addressed

The `Sentinel for EGLOT (home-manager/(nix-mode))` warning: `config.org` sets `eglot-autoshutdown t`, so killing the last nix-mode buffer tears down `nixd`, which misses `jsonrpc-shutdown`'s 300 ms grace window (`jsonrpc.el:673-686`). Cosmetic, no causal link to treesit. One reviewer suggested a modal `y-or-n-p` from `treesit-ensure-installed` could stall the event loop and contribute — if the warning persists after this lands, that's the thread to pull.

